### PR TITLE
prevent __stories__ folder build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
   "include": ["packages"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "packages/lake/__stories__"],
   "compilerOptions": {
     "module": "ESNext",
     "target": "ESNext",


### PR DESCRIPTION
By working with `build` script, I discover we build files in `__stories__`. I think we don't need to build them so I added the folder in `exclude` param. But if I'm wrong and we should keep this behavior, I think we should add `__stories__/*.js` and `__stories__/*.d.ts` files in gitignore