### PR TITLE
Input error size and color

### DIFF
--- a/packages/lake/src/components/LakeSelect.tsx
+++ b/packages/lake/src/components/LakeSelect.tsx
@@ -304,7 +304,7 @@ export function LakeSelect<V>({
       </Pressable>
 
       {!hideErrors && (
-        <LakeText variant="smallRegular" color={colors.negative[400]} style={styles.errorText}>
+        <LakeText variant="smallRegular" color={colors.negative[500]} style={styles.errorText}>
           {error ?? " "}
         </LakeText>
       )}

--- a/packages/lake/src/components/LakeTextInput.tsx
+++ b/packages/lake/src/components/LakeTextInput.tsx
@@ -300,7 +300,7 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
 
         {!hideErrors && (
           <Box direction="row" justifyContent="spaceBetween" style={styles.errorContainer}>
-            <LakeText variant="smallRegular" color={colors.negative[400]}>
+            <LakeText variant="smallRegular" color={colors.negative[500]}>
               {error ?? " "}
             </LakeText>
 


### PR DESCRIPTION
## Motivation

I discover error in `LakeTextInput` and `LakeSelect` use `regular` variant whereas in Figma design system, the variant is `smallRegular`.  
This will reduce a little (2px) the space below all inputs but our apps UI will become more consistent with Figma files.  

I also discover error color should be `negative[500]` instead of `negative[400]`