### PR TITLE
Fix terms root url

### DIFF
--- a/packages/shared-business/src/constants/termsAndConditions.ts
+++ b/packages/shared-business/src/constants/termsAndConditions.ts
@@ -32,9 +32,12 @@ export const getTermsAndConditionsPathByAccountCountryAndLocale = ({
   accountCountry?: string;
   locale: Locale;
 }) => {
+  const rootUrlWithSlash = rootUrl.endsWith("/") ? rootUrl : rootUrl + "/";
+
   if (accountCountry == null) {
-    return new URL(defaultTerms[locale], rootUrl).toString();
+    return rootUrlWithSlash + defaultTerms[locale];
   }
+
   const termsByLocale = termsAndConditions[accountCountry] ?? defaultTerms;
-  return new URL(termsByLocale[locale], rootUrl).toString();
+  return rootUrlWithSlash + termsByLocale[locale];
 };


### PR DESCRIPTION
`URL` constructor only accepts base URL with a full origin specified (http://host).
This PR fixes the `rootUrl: "/"` case (which break the account settings page in development)

<img width="472" alt="Screenshot 2023-03-27 at 18 40 00" src="https://user-images.githubusercontent.com/1902323/228007763-889e1477-b16e-4b52-b09c-8e85744cbfaa.png">
