### PR TITLE
Add UBO declaration and spanish document

### DIFF
--- a/packages/shared-business/src/locales/de.json
+++ b/packages/shared-business/src/locales/de.json
@@ -88,6 +88,8 @@
   "registrationPage.defaultNumberLabel": "Registrierungsnummer",
   "registrationPage.withOrganismLabel": "Ist Ihre Firma bereits im {organismName} eingetragen?",
   "registrationPage.withoutOrganismNameLabel": "Sind Sie registriert?",
+  "supportingDoc.UBODeclaration": "Wirtschaftlicher Eigentümer Erklärung",
+  "supportingDoc.UBODeclaration.description": "Wirtschaftlicher Eigentümer Erklärung",
   "supportingDoc.associationRegistration": "Nachweis der Registrierung",
   "supportingDoc.associationRegistration.description": "Offizielles Dokument zum Nachweis der Registrierung Ihrer Vereinigung. (weniger als 3 Monate alt)",
   "supportingDoc.companyRegistration": "Nachweis der Unternehmensregistrierung (weniger als 3 Monate alt)",

--- a/packages/shared-business/src/locales/en.json
+++ b/packages/shared-business/src/locales/en.json
@@ -88,6 +88,8 @@
   "registrationPage.defaultNumberLabel": "Registration number",
   "registrationPage.withOrganismLabel": "Are you registered to {organismName}?",
   "registrationPage.withoutOrganismNameLabel": "Are you registered?",
+  "supportingDoc.UBODeclaration": "UBO Declaration",
+  "supportingDoc.UBODeclaration.description": "Ultimate Beneficial Owners declaration of the organization",
   "supportingDoc.associationRegistration": "Proof of registration",
   "supportingDoc.associationRegistration.description": "Official document proving the registration of your association. (< 3 months old)",
   "supportingDoc.companyRegistration": "Proof of company registration (< 3 months old)",

--- a/packages/shared-business/src/locales/es.json
+++ b/packages/shared-business/src/locales/es.json
@@ -88,6 +88,8 @@
   "registrationPage.defaultNumberLabel": "Número de registro",
   "registrationPage.withOrganismLabel": "¿Está usted registrado en {organismName}?",
   "registrationPage.withoutOrganismNameLabel": "¿Está usted registrado?",
+  "supportingDoc.UBODeclaration": "Declaración de titular real",
+  "supportingDoc.UBODeclaration.description": "Declaración de titular real",
   "supportingDoc.associationRegistration": "Prueba de registro",
   "supportingDoc.associationRegistration.description": "Documento oficial que acredite el registro de tu asociación. (< 3 meses)",
   "supportingDoc.companyRegistration": "Comprobante de registro de la empresa (< 3 meses de antigüedad)",

--- a/packages/shared-business/src/locales/fr.json
+++ b/packages/shared-business/src/locales/fr.json
@@ -88,6 +88,8 @@
   "registrationPage.defaultNumberLabel": "Numéro d'immatriculation",
   "registrationPage.withOrganismLabel": "Êtes-vous immatriculé au {organismName}?",
   "registrationPage.withoutOrganismNameLabel": "Êtes-vous immatriculé?",
+  "supportingDoc.UBODeclaration": "Déclaration des bénéficiares effectifs",
+  "supportingDoc.UBODeclaration.description": "Déclaration des bénéficiares effectifs",
   "supportingDoc.associationRegistration": "Preuve d'enregistrement",
   "supportingDoc.associationRegistration.description": "Document officiel prouvant l'enregistrement de votre association. (de moins de 3 mois)",
   "supportingDoc.companyRegistration": "Preuve d'enregistrement de l'entreprise (de moins de 3 mois)",

--- a/packages/shared-business/src/locales/it.json
+++ b/packages/shared-business/src/locales/it.json
@@ -88,6 +88,8 @@
   "registrationPage.defaultNumberLabel": "Numero di registrazione",
   "registrationPage.withOrganismLabel": "Sei registrato a {organismName}?",
   "registrationPage.withoutOrganismNameLabel": "Sei registrato?",
+  "supportingDoc.UBODeclaration": "Dichiarazione di titolare effettivo",
+  "supportingDoc.UBODeclaration.description": "Dichiarazione di titolare effettivo",
   "supportingDoc.associationRegistration": "Prova di registrazione",
   "supportingDoc.associationRegistration.description": "Documento ufficiale attestante la registrazione della tua associazione. (< 3 mesi)",
   "supportingDoc.companyRegistration": "Prova di registrazione della società (< 3 mesi)",

--- a/packages/shared-business/src/locales/nl.json
+++ b/packages/shared-business/src/locales/nl.json
@@ -88,6 +88,8 @@
   "registrationPage.defaultNumberLabel": "Registratienummer",
   "registrationPage.withOrganismLabel": "Bent u geregistreerd bij {organismName}?",
   "registrationPage.withoutOrganismNameLabel": "Bent u geregistreerd?",
+  "supportingDoc.UBODeclaration": "Uiteindelijk begunstigde verklaring",
+  "supportingDoc.UBODeclaration.description": "Uiteindelijk begunstigde verklaring",
   "supportingDoc.associationRegistration": "Bewijs van inschrijving",
   "supportingDoc.associationRegistration.description": "Officieel document waaruit de registratie van uw vereniging blijkt. (minder dan 3 maanden oud)",
   "supportingDoc.companyRegistration": "Uittreksel van het handelsregister (KVK document, minder dan 3 maanden oud)",

--- a/packages/shared-business/src/locales/pt.json
+++ b/packages/shared-business/src/locales/pt.json
@@ -88,6 +88,8 @@
   "registrationPage.defaultNumberLabel": "Número de registo",
   "registrationPage.withOrganismLabel": "Você está registado no {organismName}?",
   "registrationPage.withoutOrganismNameLabel": "Você está registado?",
+  "supportingDoc.UBODeclaration": "Declaração dos beneficiários efetivos",
+  "supportingDoc.UBODeclaration.description": "Declaração dos beneficiários efetivos",
   "supportingDoc.associationRegistration": "Prova de registo",
   "supportingDoc.associationRegistration.description": "Documento oficial comprovando o registo da sua associação. (< 3 meses)",
   "supportingDoc.companyRegistration": "Prova de registo da empresa (< 3 meses)",


### PR DESCRIPTION
This PR adds some documents in `SupportingDocument`:
- UBO Declaration
- Sworn statement

It also contains a fix: Power of attorney was tagged as `Other` instead of `PowerOfAttorney`.  
As we might have user who already uploaded documents with the `Other` tag, we keep during one month the `Other` tag only to set initial values, we only upload with `PowerOfAttorney` tag with this PR.  
Another PR will be created just to remove this specific behaviour in the future.

Also `SupportingDocument` export `uploadableDocumentTypes` because there are some values from `SupportingDocumentPurposeEnum` we never display in the component. So in the onboarding we'll be able to improve the logic to know if we should display document step or not.  