### PR TITLE
Supporting document: don't display anymore "Other" documents

### DIFF
--- a/packages/shared-business/src/components/SupportingDocument.tsx
+++ b/packages/shared-business/src/components/SupportingDocument.tsx
@@ -165,9 +165,6 @@ export const SupportingDocument = forwardRef<SupportingDocumentRef, Props>(
     const [showPowerOfAttorneyModal, setShowPowerOfAttorneyModal] = useState(false);
     const [showSwornStatementModal, setShowSwornStatementModal] = useState(false);
 
-    const initialPowerOfAttorneyDocuments = initialValues["PowerOfAttorney"] ?? [];
-    const initialOtherDocuments = initialValues["Other"] ?? [];
-
     const { Field, setFieldValue, getFieldState, listenFields, submitForm } = useForm<FormValues>({
       CompanyRegistration: {
         initialValue: initialValues["CompanyRegistration"] ?? [],
@@ -190,9 +187,7 @@ export const SupportingDocument = forwardRef<SupportingDocumentRef, Props>(
         validate: validateNotEmpty,
       },
       PowerOfAttorney: {
-        // we keep initialOtherDocuments because it was the key for legacy onboarding
-        // this should be replaced by initialValues["PowerOfAttorney"] ?? [] in may 2023
-        initialValue: [...initialPowerOfAttorneyDocuments, ...initialOtherDocuments],
+        initialValue: initialValues["PowerOfAttorney"] ?? [],
         validate: validateNotEmpty,
       },
       SwornStatement: {


### PR DESCRIPTION
⚠️ This PR shouldn't be merged before the 2nd of May, you can read the description bellow to know why.

In the onboarding, we uploaded "Power of attorney" with the tag other.  
We fix it in this MR https://github.com/swan-io/lake/pull/21 but we still display "Other" documents in "Power of attorney" in case some users already uploaded the document and come back on this step.  
As this fix was deployed the 29 of March, I think we are safe if we remove this behaviour in 1 month, let's say the 2nd of May.  