### PR TITLE
Make lokalise config consistent with partner repo

### DIFF
--- a/lokalise.config.js
+++ b/lokalise.config.js
@@ -1,16 +1,10 @@
 const path = require("path");
 require("dotenv").config();
 
-const sharedBusinessProjectId = process.env.LOKALISE_SHARED_BUSINESS_PROJECT_ID;
-
-if (!sharedBusinessProjectId) {
-  throw new Error("Missing LOKALISE_SHARED_BUSINESS_PROJECT_ID env variable");
-}
-
 module.exports = [
   {
     name: "shared-business",
-    id: sharedBusinessProjectId,
+    id: "209582206299c613f25323.74831042",
     defaultLocale: "en",
     paths: {
       src: path.join(process.cwd(), "packages", "shared-business", "src"),


### PR DESCRIPTION
This PR change a little detail to make lokalise config similar with https://github.com/swan-io/swan-partner-frontend.  
It removes LOKALISE_SHARED_BUSINESS_PROJECT_ID and instead set the lokalise project id