### PR TITLE
add Monaco country for individual and company countries

### DIFF
--- a/packages/shared-business/src/constants/countries.ts
+++ b/packages/shared-business/src/constants/countries.ts
@@ -2271,6 +2271,7 @@ const names = {
   LUX: t("country.LUX"),
   LVA: t("country.LVA"),
   MLT: t("country.MLT"),
+  MCO: t("country.MCO"),
   NLD: t("country.NLD"),
   NOR: t("country.NOR"),
   POL: t("country.POL"),
@@ -2323,6 +2324,7 @@ const individualCountries = [
   "ROU",
   "SWE",
   "BGR",
+  "MCO",
 ] satisfies CountryCCA3[];
 
 export type IndividualCountryCCA3 = (typeof individualCountries)[number];
@@ -2367,6 +2369,7 @@ const companyCountries = [
   "BGR",
   "CYP",
   "NOR",
+  "MCO",
 ] satisfies CountryCCA3[];
 
 export type CompanyCountryCCA3 = (typeof companyCountries)[number];

--- a/packages/shared-business/src/locales/de.json
+++ b/packages/shared-business/src/locales/de.json
@@ -71,6 +71,7 @@
   "country.LTU": "Litauen",
   "country.LUX": "Luxemburg",
   "country.LVA": "Lettland",
+  "country.MCO": "Monaco",
   "country.MLT": "Malta",
   "country.NLD": "Niederlande",
   "country.NOR": "Norwegen",

--- a/packages/shared-business/src/locales/en.json
+++ b/packages/shared-business/src/locales/en.json
@@ -71,6 +71,7 @@
   "country.LTU": "Lithuania",
   "country.LUX": "Luxembourg",
   "country.LVA": "Latvia",
+  "country.MCO": "Monaco",
   "country.MLT": "Malta",
   "country.NLD": "Netherlands",
   "country.NOR": "Norway",

--- a/packages/shared-business/src/locales/es.json
+++ b/packages/shared-business/src/locales/es.json
@@ -71,6 +71,7 @@
   "country.LTU": "Lituania",
   "country.LUX": "Luxemburgo",
   "country.LVA": "Letonia",
+  "country.MCO": "Mónaco",
   "country.MLT": "Malta",
   "country.NLD": "Países Bajos",
   "country.NOR": "Noruega",

--- a/packages/shared-business/src/locales/fr.json
+++ b/packages/shared-business/src/locales/fr.json
@@ -71,6 +71,7 @@
   "country.LTU": "Lituanie",
   "country.LUX": "Luxembourg",
   "country.LVA": "Lettonie",
+  "country.MCO": "Monaco",
   "country.MLT": "Malte",
   "country.NLD": "Pays-Bas",
   "country.NOR": "Norvège",

--- a/packages/shared-business/src/locales/it.json
+++ b/packages/shared-business/src/locales/it.json
@@ -71,6 +71,7 @@
   "country.LTU": "Lituania",
   "country.LUX": "Lussemburgo",
   "country.LVA": "Lettonia",
+  "country.MCO": "Monaco",
   "country.MLT": "Malta",
   "country.NLD": "Paesi Bassi",
   "country.NOR": "Norvegia",

--- a/packages/shared-business/src/locales/nl.json
+++ b/packages/shared-business/src/locales/nl.json
@@ -71,6 +71,7 @@
   "country.LTU": "Lithouwen",
   "country.LUX": "Luxemburg",
   "country.LVA": "Letland",
+  "country.MCO": "Monaco",
   "country.MLT": "Malta",
   "country.NLD": "Nederland",
   "country.NOR": "Noorwegen",

--- a/packages/shared-business/src/locales/pt.json
+++ b/packages/shared-business/src/locales/pt.json
@@ -71,6 +71,7 @@
   "country.LTU": "Lituânia",
   "country.LUX": "Luxemburgo",
   "country.LVA": "Letónia",
+  "country.MCO": "Mónaco",
   "country.MLT": "Malta",
   "country.NLD": "Paises Baixos",
   "country.NOR": "Noruega",


### PR DESCRIPTION
This PR adds Monaco in the list of available countries for individual and company onboarding.  
Translations was made with github co-pilot and Deepl agrees.