### PR TITLE
fix button force background when its disabled

### DIFF
--- a/packages/lake/src/components/LakeButton.tsx
+++ b/packages/lake/src/components/LakeButton.tsx
@@ -93,6 +93,9 @@ const styles = StyleSheet.create({
     cursor: "not-allowed",
     opacity: 0.3,
   },
+  resetOpacity: {
+    opacity: 1,
+  },
   loaderContainer: {
     ...StyleSheet.absoluteFillObject,
     alignItems: "center",
@@ -195,6 +198,7 @@ export const LakeButton = memo(
             hasIconEnd && (isSmall ? styles.withIconEndSmall : styles.withIconEnd),
             hasOnlyIcon && (isSmall ? styles.iconSmallOnly : styles.iconOnly),
             disabled && styles.disabled,
+            disabled && forceBackground && styles.resetOpacity,
             grow && styles.grow,
 
             typeof style == "function" ? style({ hovered, pressed, focused }) : style,
@@ -219,7 +223,12 @@ export const LakeButton = memo(
                   ? backgroundColor.accented
                   : invariantColors.transparent,
                 borderWidth: 1,
-                borderColor: hovered ? colors[color][600] : colors[color][300],
+                borderColor:
+                  disabled && forceBackground
+                    ? colors[color][100]
+                    : hovered
+                    ? colors[color][600]
+                    : colors[color][300],
               }))
               .with("tertiary", () => ({
                 backgroundColor: pressed
@@ -234,7 +243,9 @@ export const LakeButton = memo(
           {({ pressed, hovered }) => {
             const textColor =
               mode === "secondary" || mode === "tertiary"
-                ? hovered || pressed
+                ? disabled && forceBackground
+                  ? colors[color][300]
+                  : hovered || pressed
                   ? colors[color][700]
                   : colors[color][600]
                 : colors[color].contrast;


### PR DESCRIPTION
The goal of this PR is forcing background in button even when it's disabled.  
As disabled style is reducing the opacity to `0.3`, we can see behind the button even if we set `forceBackground={true}`.  
I keep the default opacity behaviour because this is defined like this in Figma design system file.  
But if there is `forceBackground` option set, we force opacity to stay `1` and change text and background color.

Before:  
![image](https://user-images.githubusercontent.com/32013054/229084141-bb0a7b05-2d01-4d87-a1ce-59806f572a84.png)

After:  
![image](https://user-images.githubusercontent.com/32013054/229084087-3b0b7a7f-5d6f-4354-b6e1-0d7f69835f16.png)
