### PR TITLE
create push to lokalise github action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,6 @@ jobs:
       - name: Run tests
         run: yarn test
 
-      - name: Push translation keys
-        if: "contains('refs/heads/main', github.ref)"
-        run: yarn lokalise sync
-
       - name: Build Storybook
         run: yarn build-storybook
 
@@ -40,3 +36,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+
+      - name: Push translation keys
+        if: "contains('refs/heads/main', github.ref)"
+        run: yarn lokalise sync


### PR DESCRIPTION
I discover we don't push automatically new translation to Lokalise when we merge a PR.  
So this PR adds a new job running only on `main` to push new translation to Lokalise automatically.  

I create this file just by reading the other workflow and use the same command as we used in our private repository.  
But I didn't test it.