### PR TITLE
move modale close button to align icon with content

### DIFF
--- a/packages/lake/src/components/LakeModal.tsx
+++ b/packages/lake/src/components/LakeModal.tsx
@@ -6,6 +6,7 @@ import {
   backgroundColor,
   breakpoints,
   colors,
+  negativeSpacings,
   shadows,
   spacings,
 } from "../constants/design";
@@ -130,8 +131,8 @@ const styles = StyleSheet.create({
     ...StyleSheet.absoluteFillObject,
   },
   closeButton: {
-    top: -16,
-    right: -17,
+    top: negativeSpacings[16],
+    right: negativeSpacings[16],
   },
 });
 


### PR DESCRIPTION
This PR align modal close icon with modal content

Before:  
<img width="589" alt="image" src="https://user-images.githubusercontent.com/32013054/229799386-3e4a9860-f956-4f65-af07-c5e42e34a6d6.png">

After:  
<img width="583" alt="image" src="https://user-images.githubusercontent.com/32013054/229799264-c564883e-32b1-4125-b4ca-3d4da63681c6.png">
