### PR TITLE
Trigger onChange when boolean filter is enabled

### DIFF
--- a/packages/lake/src/components/Filters.tsx
+++ b/packages/lake/src/components/Filters.tsx
@@ -360,6 +360,7 @@ type FilterDateProps = {
   onPressRemove: () => void;
   autoOpen?: boolean;
 };
+
 function FilterDate({
   label,
   initialValue,
@@ -538,6 +539,22 @@ function FilterInput({
   );
 }
 
+type FilterBooleanTagProps = {
+  children: string;
+  onAdd: () => void;
+  onPressRemove: () => void;
+};
+
+function FilterBooleanTag({ children, onAdd, onPressRemove }: FilterBooleanTagProps) {
+  useEffect(onAdd, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <Tag color="current" onPressRemove={onPressRemove}>
+      {children}
+    </Tag>
+  );
+}
+
 export type FilterCheckboxDef<T> = {
   type: "checkbox";
   label: string;
@@ -711,15 +728,17 @@ export const FiltersStack = <T extends FiltersDefinition>({
                 ),
               )
               .with({ type: "boolean" }, ({ label }) => (
-                <Tag
-                  color="current"
+                <FilterBooleanTag
+                  onAdd={() => {
+                    onChangeFilters({ ...filters, [filterName]: true });
+                  }}
                   onPressRemove={() => {
                     onChangeFilters({ ...filters, [filterName]: undefined });
                     onChangeOpened(openedFilters.filter(f => f !== filterName));
                   }}
                 >
                   {label}
-                </Tag>
+                </FilterBooleanTag>
               ))
               .exhaustive()}
           </View>


### PR DESCRIPTION
Currently, `onChange` is not called when adding a `boolean` filter and we have to add a condition in `onAddFilter` to make it works:

```tsx
onAddFilter={filter => {
  // this is considered a workaround:
  if (filter === "canceled") {
    setFilters(filters => ({ ...filters, canceled: true }));
  }
  setOpenFilters(openFilters => [...openFilters, filter]);
}}
```

This PR remove the need for that, making `boolean` filter works like the others.