### PR TITLE
Add condition to change the country in GMapsAddressSearchInput

### DIFF
--- a/packages/shared-business/src/components/GMapAddressSearchInput.tsx
+++ b/packages/shared-business/src/components/GMapAddressSearchInput.tsx
@@ -102,10 +102,7 @@ export const GMapAddressSearchInput = ({
           );
 
           onSuggestion?.({
-            city: result.value.city,
-            completeAddress: result.value.completeAddress,
-            postalCode: result.value.postalCode,
-            streetNumber: result.value.streetNumber,
+            ...result.value,
             country: dependsOnCountriesWithMultipleCCA3 === true ? country : result.value.country,
           });
         }


### PR DESCRIPTION
Problem: if the selected country has multiple cca3, the Gmaps search works well but it automatically updates the country field with the wrong cca3.
Change: add condition for the country value
