### PR TITLE
Breadcrumb dropdown fix

### DIFF
--- a/packages/lake/src/components/Breadcrumbs.tsx
+++ b/packages/lake/src/components/Breadcrumbs.tsx
@@ -256,9 +256,11 @@ const CHEVRON = (
 
 const BreadcrumbsSiblingsDropdown = ({
   siblings,
+  isLast,
   onPress,
 }: {
   siblings: NonNullable<Crumb["siblings"]>;
+  isLast: boolean;
   onPress: () => void;
 }) => {
   return (
@@ -270,7 +272,7 @@ const BreadcrumbsSiblingsDropdown = ({
             key={url}
             ariaCurrentValue="location"
             onPress={(event: React.MouseEvent<HTMLAnchorElement>) => {
-              if (isMatching) {
+              if (isMatching && isLast) {
                 event.preventDefault();
               }
               onPress();
@@ -379,6 +381,7 @@ const BreadcrumbsItem = ({
               >
                 <BreadcrumbsSiblingsDropdown
                   siblings={siblings}
+                  isLast={isLastItem}
                   onPress={() => setSiblings(null)}
                 />
               </FocusTrap>


### PR DESCRIPTION
In the breadcrumb dropdown, we prevent click on matched item, but we weren't able to go back if we were in a sub-section (in my case card settings page).  

This PR enable press on matching item except if this is the last item.  

Here are 2 videos showing before/after:


https://user-images.githubusercontent.com/32013054/230584105-9860d6db-5b9c-49da-a9b4-9e54cd4df42c.mov

https://user-images.githubusercontent.com/32013054/230584122-e4cd0a0c-79a3-4619-8fa3-33456b3a4e5f.mov


