### PR TITLE
add stories for Tag component and fix positive color

### DIFF
--- a/packages/lake/__stories__/Tag.stories.tsx
+++ b/packages/lake/__stories__/Tag.stories.tsx
@@ -4,17 +4,17 @@ import { Box } from "../src/components/Box";
 import { ProjectEnvTag } from "../src/components/ProjectEnvTag";
 import { Space } from "../src/components/Space";
 import { Tag } from "../src/components/Tag";
-import { colors, ColorVariants } from "../src/constants/design";
+import { colors, ColorVariants, spacings } from "../src/constants/design";
 import { noop } from "../src/utils/function";
 import { StoryBlock, StoryPart } from "./_StoriesComponents";
 
-export const styles = StyleSheet.create({
+const styles = StyleSheet.create({
   container: {
     flexWrap: "wrap",
   },
   tag: {
-    marginRight: 12,
-    marginBottom: 12,
+    marginRight: spacings[12],
+    marginBottom: spacings[12],
   },
 });
 

--- a/packages/lake/__stories__/Tag.stories.tsx
+++ b/packages/lake/__stories__/Tag.stories.tsx
@@ -1,43 +1,87 @@
-import { ComponentMeta } from "@storybook/react";
-import { Grid } from "../src/components/Grid";
+import { Meta } from "@storybook/react";
+import { StyleSheet } from "react-native";
+import { Box } from "../src/components/Box";
 import { ProjectEnvTag } from "../src/components/ProjectEnvTag";
+import { Space } from "../src/components/Space";
 import { Tag } from "../src/components/Tag";
+import { colors, ColorVariants } from "../src/constants/design";
+import { noop } from "../src/utils/function";
 import { StoryBlock, StoryPart } from "./_StoriesComponents";
+
+export const styles = StyleSheet.create({
+  container: {
+    flexWrap: "wrap",
+  },
+  tag: {
+    marginRight: 12,
+    marginBottom: 12,
+  },
+});
 
 export default {
   title: "Informations/Tag",
   component: Tag,
-} as ComponentMeta<typeof Tag>;
+} as Meta<typeof Tag>;
 
 export const All = () => {
   return (
     <StoryBlock title="Tag">
-      <StoryPart title="Tag colors">
-        <Grid numColumns={5} verticalSpace={4}>
-          <Tag color="live">Simple</Tag>
-          <Tag color="sandbox">Sandbox</Tag>
+      <StoryPart title="Default">
+        <Box direction="row" style={styles.container}>
+          {Object.keys(colors).map(color => (
+            <Tag key={color} style={styles.tag} color={color as ColorVariants}>
+              Value
+            </Tag>
+          ))}
+        </Box>
+      </StoryPart>
 
-          <Tag color="negative" onPressRemove={console.log}>
-            Dismiss
-          </Tag>
+      <StoryPart title="With label">
+        <Box direction="row" style={styles.container}>
+          {Object.keys(colors).map(color => (
+            <Tag key={color} label="Label" style={styles.tag} color={color as ColorVariants}>
+              Value
+            </Tag>
+          ))}
+        </Box>
+      </StoryPart>
 
-          <Tag color="warning" label="Label">
-            O_o
-          </Tag>
+      <StoryPart title="With dismiss">
+        <Box direction="row" style={styles.container}>
+          {Object.keys(colors).map(color => (
+            <Tag key={color} onPressRemove={noop} style={styles.tag} color={color as ColorVariants}>
+              Value
+            </Tag>
+          ))}
+        </Box>
+      </StoryPart>
 
-          <Tag color="gray" onPressRemove={console.log} label="Label">
-            All
-          </Tag>
-        </Grid>
+      <StoryPart title="With label and dismiss">
+        <Box direction="row" style={styles.container}>
+          {Object.keys(colors).map(color => (
+            <Tag
+              key={color}
+              label="Label"
+              onPressRemove={noop}
+              style={styles.tag}
+              color={color as ColorVariants}
+            >
+              Value
+            </Tag>
+          ))}
+        </Box>
       </StoryPart>
 
       <StoryPart title="Env tags">
-        <Grid numColumns={5} verticalSpace={4}>
+        <Box direction="row" style={styles.container}>
           <ProjectEnvTag projectEnv="Live" />
+          <Space width={12} height={12} />
           <ProjectEnvTag projectEnv="Sandbox" />
+          <Space width={12} height={12} />
           <ProjectEnvTag projectEnv="Live" iconOnly={true} />
+          <Space width={12} height={12} />
           <ProjectEnvTag projectEnv="Sandbox" iconOnly={true} />
-        </Grid>
+        </Box>
       </StoryPart>
     </StoryBlock>
   );

--- a/packages/lake/src/assets/main.css
+++ b/packages/lake/src/assets/main.css
@@ -172,8 +172,8 @@ body {
   --color-positive-500: #1fd286;
   --color-positive-400: #4cdb9e;
   --color-positive-300: #79e4b6;
-  --color-positive-200: #d2f6e7;
-  --color-positive-100: #f4fdf9;
+  --color-positive-200: #a5edcf;
+  --color-positive-100: #d2f6e7;
   --color-positive-50: #f4fdf9;
   --color-positive-0: #f8fefb;
   --color-positive-primary: var(--color-positive-700);


### PR DESCRIPTION
By working with tags, I discover an issue with positive color which wasn't sync with our design system on Figma.  
This PR fix positive color and add some stories for Tag components.  
I tried only in storybook but not our apps, but I'm confident this will not break our apps.