### PR TITLE
Create date picker

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,17 @@
+import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import localizedFormat from "dayjs/plugin/localizedFormat";
+import relativeTime from "dayjs/plugin/relativeTime";
+import utc from "dayjs/plugin/utc";
 import "../packages/lake/src/assets/fonts/Inter.css";
 import "../packages/lake/src/assets/fonts/InterCard.css";
 import "../packages/lake/src/assets/main.css";
+
+// https://day.js.org/docs/en/plugin/plugin
+dayjs.extend(utc);
+dayjs.extend(customParseFormat);
+dayjs.extend(relativeTime);
+dayjs.extend(localizedFormat);
 
 export const parameters = {
   actions: {

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -137,14 +137,14 @@ export const Range = () => {
     <WithPartnerAccentColor color="#0F6FDE">
       <StoryBlock title="DateRangePicker">
         <StoryPart title="Default">
-          <InteractiveDateRangePicker
-            firstWeekDay="monday"
-            monthNames={monthNames}
-            weekDayNames={dayNames}
-            format="DD/MM/YYYY"
-            cancelLabel="Cancel"
-            confirmLabel="Select"
-          />
+          <View style={styles.container}>
+            <InteractiveDateRangePicker
+              firstWeekDay="monday"
+              monthNames={monthNames}
+              weekDayNames={dayNames}
+              format="DD/MM/YYYY"
+            />
+          </View>
         </StoryPart>
       </StoryBlock>
     </WithPartnerAccentColor>

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -2,7 +2,7 @@ import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Except } from "type-fest";
-import { DatePicker, DatePickerProps } from "../src/components/DatePicker";
+import { DatePicker, DatePickerProps, isTodayOrFutureDate } from "../src/components/DatePicker";
 import { WithPartnerAccentColor } from "../src/components/WithPartnerAccentColor";
 import { StoryBlock, StoryPart } from "./_StoriesComponents";
 
@@ -50,9 +50,9 @@ const dayNames = [
 
 export const Default = () => {
   return (
-    <StoryBlock title="DatePicker">
-      <StoryPart title="Default">
-        <WithPartnerAccentColor color="#0F6FDE">
+    <WithPartnerAccentColor color="#0F6FDE">
+      <StoryBlock title="DatePicker">
+        <StoryPart title="Default">
           <View style={styles.container}>
             <InteractiveDatePicker
               firstWeekDay="monday"
@@ -61,8 +61,31 @@ export const Default = () => {
               format="DD/MM/YYYY"
             />
           </View>
-        </WithPartnerAccentColor>
-      </StoryPart>
-    </StoryBlock>
+        </StoryPart>
+
+        <StoryPart title="Week starting sunday">
+          <View style={styles.container}>
+            <InteractiveDatePicker
+              firstWeekDay="sunday"
+              monthNames={monthNames}
+              weekDayNames={dayNames}
+              format="DD/MM/YYYY"
+            />
+          </View>
+        </StoryPart>
+
+        <StoryPart title="Selectable only in the future">
+          <View style={styles.container}>
+            <InteractiveDatePicker
+              firstWeekDay="sunday"
+              monthNames={monthNames}
+              weekDayNames={dayNames}
+              format="DD/MM/YYYY"
+              isSelectable={isTodayOrFutureDate}
+            />
+          </View>
+        </StoryPart>
+      </StoryBlock>
+    </WithPartnerAccentColor>
   );
 };

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -2,7 +2,13 @@ import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Except } from "type-fest";
-import { DatePicker, DatePickerProps, isTodayOrFutureDate } from "../src/components/DatePicker";
+import {
+  DatePicker,
+  DatePickerProps,
+  DateRangePicker,
+  DateRangePickerProps,
+  isTodayOrFutureDate,
+} from "../src/components/DatePicker";
 import { WithPartnerAccentColor } from "../src/components/WithPartnerAccentColor";
 import { StoryBlock, StoryPart } from "./_StoriesComponents";
 
@@ -21,6 +27,14 @@ const InteractiveDatePicker = ({ ...props }: Except<DatePickerProps, "value" | "
   const [value, setValue] = useState<string>();
 
   return <DatePicker {...props} value={value} onChange={setValue} />;
+};
+
+const InteractiveDateRangePicker = ({
+  ...props
+}: Except<DateRangePickerProps, "value" | "onChange">) => {
+  const [value, setValue] = useState({ start: "", end: "" });
+
+  return <DateRangePicker {...props} value={value} onChange={setValue} />;
 };
 
 const monthNames = [
@@ -84,6 +98,25 @@ export const Default = () => {
               isSelectable={isTodayOrFutureDate}
             />
           </View>
+        </StoryPart>
+      </StoryBlock>
+    </WithPartnerAccentColor>
+  );
+};
+
+export const Range = () => {
+  return (
+    <WithPartnerAccentColor color="#0F6FDE">
+      <StoryBlock title="DateRangePicker">
+        <StoryPart title="Default">
+          <InteractiveDateRangePicker
+            firstWeekDay="monday"
+            monthNames={monthNames}
+            weekDayNames={dayNames}
+            format="DD/MM/YYYY"
+            cancelLabel="Cancel"
+            confirmLabel="Select"
+          />
         </StoryPart>
       </StoryBlock>
     </WithPartnerAccentColor>

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -7,6 +7,7 @@ import {
   DatePickerProps,
   DateRangePicker,
   DateRangePickerProps,
+  isDateInRange,
   isTodayOrFutureDate,
   validateDateRangeOrder,
 } from "../src/components/DatePicker";
@@ -18,6 +19,12 @@ const styles = StyleSheet.create({
     width: 430,
   },
 });
+
+const FIFTEEN_DAYS_AGO = new Date();
+FIFTEEN_DAYS_AGO.setDate(FIFTEEN_DAYS_AGO.getDate() - 15);
+
+const FIFTEEN_DAYS_LATER = new Date();
+FIFTEEN_DAYS_LATER.setDate(FIFTEEN_DAYS_LATER.getDate() + 15);
 
 export default {
   title: "Forms/DatePicker",
@@ -105,6 +112,18 @@ export const Default = () => {
               weekDayNames={dayNames}
               format="DD/MM/YYYY"
               isSelectable={isTodayOrFutureDate}
+            />
+          </View>
+        </StoryPart>
+
+        <StoryPart title="Selectable only in a range (15 days before or after today)">
+          <View style={styles.container}>
+            <InteractiveDatePicker
+              firstWeekDay="sunday"
+              monthNames={monthNames}
+              weekDayNames={dayNames}
+              format="DD/MM/YYYY"
+              isSelectable={isDateInRange(FIFTEEN_DAYS_AGO, FIFTEEN_DAYS_LATER)}
             />
           </View>
         </StoryPart>

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -1,0 +1,68 @@
+import { Meta } from "@storybook/react";
+import { useState } from "react";
+import { StyleSheet, View } from "react-native";
+import { Except } from "type-fest";
+import { DatePicker, DatePickerProps } from "../src/components/DatePicker";
+import { WithPartnerAccentColor } from "../src/components/WithPartnerAccentColor";
+import { StoryBlock, StoryPart } from "./_StoriesComponents";
+
+const styles = StyleSheet.create({
+  container: {
+    width: 430,
+  },
+});
+
+export default {
+  title: "Forms/DatePicker",
+  component: DatePicker,
+} as Meta<typeof DatePicker>;
+
+const InteractiveDatePicker = ({ ...props }: Except<DatePickerProps, "value" | "onChange">) => {
+  const [value, setValue] = useState<string>();
+
+  return <DatePicker {...props} value={value} onChange={setValue} />;
+};
+
+const monthNames = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+
+const dayNames = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+] as const;
+
+export const Default = () => {
+  return (
+    <StoryBlock title="DatePicker">
+      <StoryPart title="Default">
+        <WithPartnerAccentColor color="#0F6FDE">
+          <View style={styles.container}>
+            <InteractiveDatePicker
+              firstWeekDay="monday"
+              monthNames={monthNames}
+              weekDayNames={dayNames}
+              format="DD/MM/YYYY"
+            />
+          </View>
+        </WithPartnerAccentColor>
+      </StoryPart>
+    </StoryBlock>
+  );
+};

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -1,9 +1,10 @@
 import { Meta } from "@storybook/react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Except } from "type-fest";
 import {
   DatePicker,
+  DatePickerPopover,
   DatePickerProps,
   DateRangePicker,
   DateRangePickerProps,
@@ -11,12 +12,18 @@ import {
   isTodayOrFutureDate,
   validateDateRangeOrder,
 } from "../src/components/DatePicker";
+import { LakeButton } from "../src/components/LakeButton";
+import { LakeText } from "../src/components/LakeText";
+import { Space } from "../src/components/Space";
 import { WithPartnerAccentColor } from "../src/components/WithPartnerAccentColor";
 import { StoryBlock, StoryPart } from "./_StoriesComponents";
 
 const styles = StyleSheet.create({
   container: {
     width: 430,
+  },
+  button: {
+    alignSelf: "flex-start",
   },
 });
 
@@ -126,6 +133,42 @@ export const Default = () => {
               isSelectable={isDateInRange(FIFTEEN_DAYS_AGO, FIFTEEN_DAYS_LATER)}
             />
           </View>
+        </StoryPart>
+      </StoryBlock>
+    </WithPartnerAccentColor>
+  );
+};
+
+export const ButtonWithPopover = () => {
+  const buttonRef = useRef<View | null>(null);
+  const [value, setValue] = useState("");
+  const [isOpened, setIsOpened] = useState(false);
+
+  return (
+    <WithPartnerAccentColor color="#0F6FDE">
+      <StoryBlock title="DatePicker Popover">
+        <StoryPart title="Default">
+          <LakeText>Selected date: {value}</LakeText>
+          <Space height={20} />
+
+          <LakeButton ref={buttonRef} style={styles.button} onPress={() => setIsOpened(true)}>
+            Open date picker
+          </LakeButton>
+
+          <DatePickerPopover
+            visible={isOpened}
+            monthNames={monthNames}
+            weekDayNames={dayNames}
+            referenceRef={buttonRef}
+            value={value}
+            firstWeekDay="monday"
+            format="DD/MM/YYYY"
+            inputLabel="Select a date"
+            confirmLabel="Select"
+            cancelLabel="Cancel"
+            onChange={setValue}
+            onDissmiss={() => setIsOpened(false)}
+          />
         </StoryPart>
       </StoryBlock>
     </WithPartnerAccentColor>

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -20,7 +20,7 @@ import { StoryBlock, StoryPart } from "./_StoriesComponents";
 
 const styles = StyleSheet.create({
   container: {
-    width: 430,
+    maxWidth: 430,
   },
   button: {
     alignSelf: "flex-start",

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -7,6 +7,7 @@ import {
   DatePickerPopover,
   DatePickerProps,
   DateRangePicker,
+  DateRangePickerPopover,
   DateRangePickerProps,
   isDateInRange,
   isTodayOrFutureDate,
@@ -194,6 +195,46 @@ export const Range = () => {
               format="DD/MM/YYYY"
             />
           </View>
+        </StoryPart>
+      </StoryBlock>
+    </WithPartnerAccentColor>
+  );
+};
+
+export const ButtonWithRangePopover = () => {
+  const buttonRef = useRef<View | null>(null);
+  const [value, setValue] = useState({ start: "", end: "" });
+  const [isOpened, setIsOpened] = useState(false);
+
+  return (
+    <WithPartnerAccentColor color="#0F6FDE">
+      <StoryBlock title="DatePicker Popover">
+        <StoryPart title="Default">
+          <LakeText>
+            Selected date: {value.start} - {value.end}
+          </LakeText>
+
+          <Space height={20} />
+
+          <LakeButton ref={buttonRef} style={styles.button} onPress={() => setIsOpened(true)}>
+            Open date range picker
+          </LakeButton>
+
+          <DateRangePickerPopover
+            visible={isOpened}
+            monthNames={monthNames}
+            weekDayNames={dayNames}
+            referenceRef={buttonRef}
+            value={value}
+            firstWeekDay="monday"
+            format="DD/MM/YYYY"
+            startLabel="Start date"
+            endLabel="End date"
+            confirmLabel="Select"
+            cancelLabel="Cancel"
+            onChange={setValue}
+            onDissmiss={() => setIsOpened(false)}
+          />
         </StoryPart>
       </StoryBlock>
     </WithPartnerAccentColor>

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -7,7 +7,7 @@ import {
   DatePickerPopover,
   DatePickerProps,
   DateRangePicker,
-  DateRangePickerPopover,
+  DateRangePickerModal,
   DateRangePickerProps,
   isDateInRange,
   isTodayOrFutureDate,
@@ -202,7 +202,6 @@ export const Range = () => {
 };
 
 export const ButtonWithRangePopover = () => {
-  const buttonRef = useRef<View | null>(null);
   const [value, setValue] = useState({ start: "", end: "" });
   const [isOpened, setIsOpened] = useState(false);
 
@@ -216,15 +215,14 @@ export const ButtonWithRangePopover = () => {
 
           <Space height={20} />
 
-          <LakeButton ref={buttonRef} style={styles.button} onPress={() => setIsOpened(true)}>
+          <LakeButton style={styles.button} onPress={() => setIsOpened(true)}>
             Open date range picker
           </LakeButton>
 
-          <DateRangePickerPopover
+          <DateRangePickerModal
             visible={isOpened}
             monthNames={monthNames}
             weekDayNames={dayNames}
-            referenceRef={buttonRef}
             value={value}
             firstWeekDay="monday"
             format="DD/MM/YYYY"

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -92,6 +92,7 @@ export const Default = () => {
         <StoryPart title="Default">
           <View style={styles.container}>
             <InteractiveDatePicker
+              label="Select a date"
               firstWeekDay="monday"
               monthNames={monthNames}
               weekDayNames={dayNames}
@@ -103,6 +104,7 @@ export const Default = () => {
         <StoryPart title="Week starting sunday">
           <View style={styles.container}>
             <InteractiveDatePicker
+              label="Select a date"
               firstWeekDay="sunday"
               monthNames={monthNames}
               weekDayNames={dayNames}
@@ -114,6 +116,7 @@ export const Default = () => {
         <StoryPart title="Selectable only in the future">
           <View style={styles.container}>
             <InteractiveDatePicker
+              label="Select a date"
               firstWeekDay="sunday"
               monthNames={monthNames}
               weekDayNames={dayNames}
@@ -126,6 +129,7 @@ export const Default = () => {
         <StoryPart title="Selectable only in a range (15 days before or after today)">
           <View style={styles.container}>
             <InteractiveDatePicker
+              label="Select a date"
               firstWeekDay="sunday"
               monthNames={monthNames}
               weekDayNames={dayNames}
@@ -163,7 +167,7 @@ export const ButtonWithPopover = () => {
             value={value}
             firstWeekDay="monday"
             format="DD/MM/YYYY"
-            inputLabel="Select a date"
+            label="Select a date"
             confirmLabel="Select"
             cancelLabel="Cancel"
             onChange={setValue}

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -8,6 +8,7 @@ import {
   DateRangePicker,
   DateRangePickerProps,
   isTodayOrFutureDate,
+  validateDateRangeOrder,
 } from "../src/components/DatePicker";
 import { WithPartnerAccentColor } from "../src/components/WithPartnerAccentColor";
 import { StoryBlock, StoryPart } from "./_StoriesComponents";
@@ -33,8 +34,16 @@ const InteractiveDateRangePicker = ({
   ...props
 }: Except<DateRangePickerProps, "value" | "onChange">) => {
   const [value, setValue] = useState({ start: "", end: "" });
+  const isRangeValid = validateDateRangeOrder(value, props.format);
 
-  return <DateRangePicker {...props} value={value} onChange={setValue} />;
+  return (
+    <DateRangePicker
+      {...props}
+      value={value}
+      error={isRangeValid ? undefined : "End date can't be before start date"}
+      onChange={setValue}
+    />
+  );
 };
 
 const monthNames = [

--- a/packages/lake/__stories__/DatePicker.stories.tsx
+++ b/packages/lake/__stories__/DatePicker.stories.tsx
@@ -182,6 +182,8 @@ export const Range = () => {
         <StoryPart title="Default">
           <View style={styles.container}>
             <InteractiveDateRangePicker
+              startLabel="Start date"
+              endLabel="End date"
               firstWeekDay="monday"
               monthNames={monthNames}
               weekDayNames={dayNames}

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -211,34 +211,33 @@ const padEnd = <T,>(input: T[], length: number, value: T): T[] => {
 };
 
 export const isTodayOrFutureDate = (date: DatePickerDate): boolean => {
-  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
 
-  return (
-    date.year >= today.getFullYear() &&
-    date.month >= today.getMonth() &&
-    date.day >= today.getDate()
-  );
+  const yesterdayDate: DatePickerDate = {
+    day: yesterday.getDate(),
+    month: yesterday.getMonth(),
+    year: yesterday.getFullYear(),
+  };
+
+  return isDateAfter(date, yesterdayDate);
 };
 
 export const isDateInRange =
   (minDate: Date, maxDate: Date) =>
   (date: DatePickerDate): boolean => {
-    const minDay = minDate.getDate();
-    const minMonth = minDate.getMonth();
-    const minYear = minDate.getFullYear();
+    const min: DatePickerDate = {
+      day: minDate.getDate(),
+      month: minDate.getMonth(),
+      year: minDate.getFullYear(),
+    };
+    const max: DatePickerDate = {
+      day: maxDate.getDate(),
+      month: maxDate.getMonth(),
+      year: maxDate.getFullYear(),
+    };
 
-    const maxDay = maxDate.getDate();
-    const maxMonth = maxDate.getMonth();
-    const maxYear = maxDate.getFullYear();
-
-    return (
-      date.day >= minDay &&
-      date.month >= minMonth &&
-      date.year >= minYear &&
-      date.day <= maxDay &&
-      date.month <= maxMonth &&
-      date.year <= maxYear
-    );
+    return isDateAfter(date, min) && isDateBefore(date, max);
   };
 
 const isDateToday = (date: DatePickerDate): boolean => {

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -1283,3 +1283,151 @@ export const DateRangePicker = ({
     </View>
   );
 };
+
+type DateRangePickerPopoverProps = DateRangePickerProps & {
+  id?: string;
+  visible: boolean;
+  referenceRef: React.RefObject<unknown>;
+  cancelLabel: string;
+  confirmLabel: string;
+  onDissmiss: () => void;
+};
+
+export const DateRangePickerPopover = ({
+  value,
+  error,
+  format,
+  firstWeekDay,
+  monthNames,
+  weekDayNames,
+  isSelectable,
+  onChange,
+  id,
+  visible,
+  referenceRef,
+  startLabel,
+  endLabel,
+  cancelLabel,
+  confirmLabel,
+  onDissmiss,
+}: DateRangePickerPopoverProps) => {
+  const { desktop } = useResponsive(DATE_PICKER_MOBILE_THRESHOLD);
+  const { desktop: displayTwoCalendar } = useResponsive(DATE_RANGE_PICKER_THRESHOLD);
+  const [localeValue, setLocaleValue] = useState(value);
+
+  useEffect(() => {
+    setLocaleValue(value);
+  }, [value]);
+
+  const handleStartChange = (start: string) => {
+    setLocaleValue({ start, end: localeValue.end });
+  };
+
+  const handleEndChange = (end: string) => {
+    setLocaleValue({ start: localeValue.start, end });
+  };
+
+  const handleCancel = () => {
+    setLocaleValue(value);
+    onDissmiss();
+  };
+
+  const handleConfirm = () => {
+    onChange(localeValue);
+    onDissmiss();
+  };
+
+  return (
+    <Popover
+      id={id}
+      role="dialog"
+      onDismiss={handleCancel}
+      referenceRef={referenceRef}
+      autoFocus={true}
+      returnFocus={false}
+      visible={visible}
+    >
+      <View style={desktop ? styles.popoverDesktop : styles.popover}>
+        <View>
+          <Box direction="row" alignItems="end">
+            <LakeLabel
+              label={startLabel}
+              style={styles.label}
+              render={() => (
+                <Rifm value={localeValue.start} onChange={handleStartChange} {...rifmDateProps}>
+                  {({ value, onChange }) => (
+                    <LakeTextInput
+                      placeholder={format}
+                      value={value}
+                      onChange={onChange}
+                      error={error}
+                      hideErrors={true}
+                    />
+                  )}
+                </Rifm>
+              )}
+            />
+
+            <Space width={12} />
+
+            <Box style={styles.arrowContainer} justifyContent="center">
+              <Icon name="arrow-right-filled" size={20} />
+            </Box>
+
+            <Space width={12} />
+
+            <LakeLabel
+              label={endLabel}
+              style={styles.label}
+              render={() => (
+                <Rifm value={localeValue.end} onChange={handleEndChange} {...rifmDateProps}>
+                  {({ value, onChange }) => (
+                    <LakeTextInput
+                      placeholder={format}
+                      value={value}
+                      onChange={onChange}
+                      error={error}
+                      hideErrors={true}
+                    />
+                  )}
+                </Rifm>
+              )}
+            />
+          </Box>
+
+          <Space height={4} />
+
+          <LakeText variant="smallRegular" color={colors.negative[500]}>
+            {error ?? " "}
+          </LakeText>
+        </View>
+
+        <DateRangePickerPopoverContent
+          value={localeValue}
+          format={format}
+          firstWeekDay={firstWeekDay}
+          monthNames={monthNames}
+          weekDayNames={weekDayNames}
+          desktop={desktop}
+          displayTwoCalendar={displayTwoCalendar}
+          isSelectable={isSelectable}
+          onChange={setLocaleValue}
+        />
+
+        <Space height={24} />
+
+        <Box direction="row" alignItems="center">
+          <LakeButton mode="secondary" size="small" onPress={handleCancel} style={styles.button}>
+            {cancelLabel}
+          </LakeButton>
+
+          <Space width={24} />
+
+          <LakeButton color="current" size="small" onPress={handleConfirm} style={styles.button}>
+            {confirmLabel}
+          </LakeButton>
+        </Box>
+      </View>
+    </Popover>
+  );
+};

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -833,8 +833,6 @@ export type DateRangePickerProps = {
   weekDayNames: WeekDayNames;
   isSelectable?: (date: DatePickerDate) => boolean;
   onChange: (date: { start: string; end: string }) => void;
-  cancelLabel: string;
-  confirmLabel: string;
 };
 
 const DateRangePickerPopover = ({
@@ -845,8 +843,6 @@ const DateRangePickerPopover = ({
   weekDayNames,
   isSelectable,
   onChange,
-  cancelLabel,
-  confirmLabel,
 }: DateRangePickerProps) => {
   const [periods, setPeriods] = useState(() => {
     const startYearMonth = getYearMonth(value.start, format).getWithDefault(getTodayYearMonth());
@@ -986,20 +982,6 @@ const DateRangePickerPopover = ({
           />
         </View>
       </Box>
-
-      <Space height={24} />
-
-      <Box direction="row" alignItems="start">
-        <LakeButton size="small" mode="secondary" style={styles.button}>
-          {cancelLabel}
-        </LakeButton>
-
-        <Space width={48} />
-
-        <LakeButton size="small" mode="primary" color="current" style={styles.button}>
-          {confirmLabel}
-        </LakeButton>
-      </Box>
     </View>
   );
 };
@@ -1013,9 +995,11 @@ export const DateRangePicker = ({
   weekDayNames,
   isSelectable,
   onChange,
-  cancelLabel,
-  confirmLabel,
 }: DateRangePickerProps) => {
+  const ref = useRef<TextInput>(null);
+  const [isOpened, { open, close }] = useDisclosure(false);
+  const popoverId = useId();
+
   const handleStartChange = useCallback(
     (start: string) => {
       onChange({ start, end: value.end });
@@ -1036,11 +1020,13 @@ export const DateRangePicker = ({
         <Rifm value={value.start} onChange={handleStartChange} {...rifmDateProps}>
           {({ value, onChange }) => (
             <LakeTextInput
+              ref={ref}
               placeholder={format}
               value={value}
               onChange={onChange}
               error={error}
               hideErrors={true}
+              ariaExpanded={isOpened}
             />
           )}
         </Rifm>
@@ -1057,9 +1043,13 @@ export const DateRangePicker = ({
               onChange={onChange}
               error={error}
               hideErrors={true}
+              ariaExpanded={isOpened}
             />
           )}
         </Rifm>
+
+        <Space width={12} />
+        <LakeButton mode="secondary" icon="calendar-ltr-regular" size="small" onPress={open} />
       </Box>
 
       <Space height={4} />
@@ -1068,17 +1058,27 @@ export const DateRangePicker = ({
         {error ?? " "}
       </LakeText>
 
-      <DateRangePickerPopover
-        value={value}
-        format={format}
-        firstWeekDay={firstWeekDay}
-        monthNames={monthNames}
-        weekDayNames={weekDayNames}
-        isSelectable={isSelectable}
-        onChange={onChange}
-        cancelLabel={cancelLabel}
-        confirmLabel={confirmLabel}
-      />
+      <Popover
+        id={popoverId}
+        role="dialog"
+        onDismiss={close}
+        referenceRef={ref}
+        autoFocus={true}
+        returnFocus={false}
+        visible={isOpened}
+        underlay={false}
+        forcedMode="Dropdown"
+      >
+        <DateRangePickerPopover
+          value={value}
+          format={format}
+          firstWeekDay={firstWeekDay}
+          monthNames={monthNames}
+          weekDayNames={weekDayNames}
+          isSelectable={isSelectable}
+          onChange={onChange}
+        />
+      </Popover>
     </View>
   );
 };

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react"
 import { StyleSheet, TextInput, View } from "react-native";
 import { Rifm } from "rifm";
 import { P, match } from "ts-pattern";
+import { Except } from "type-fest";
 import { colors, spacings } from "../constants/design";
 import { useDisclosure } from "../hooks/useDisclosure";
 import { useFirstMountState } from "../hooks/useFirstMountState";
@@ -25,6 +26,12 @@ import { Separator } from "./Separator";
 import { Space } from "./Space";
 
 const styles = StyleSheet.create({
+  label: {
+    flex: 1,
+  },
+  arrowContainer: {
+    height: 40, // input height
+  },
   popover: {
     padding: spacings[12],
   },
@@ -937,11 +944,21 @@ export type DateRangePickerProps = {
   value: { start: string; end: string };
   error?: string;
   format: DateFormat;
+  startLabel: string;
+  endLabel: string;
   firstWeekDay: keyof typeof weekDayIndex;
   monthNames: MonthNames;
   weekDayNames: WeekDayNames;
   isSelectable?: (date: DatePickerDate) => boolean;
   onChange: (date: { start: string; end: string }) => void;
+};
+
+type DateRangePickerPopoverContentProps = Except<
+  DateRangePickerProps,
+  "startLabel" | "endLabel"
+> & {
+  desktop: boolean;
+  displayTwoCalendar: boolean;
 };
 
 const DateRangePickerPopoverContent = ({
@@ -954,7 +971,7 @@ const DateRangePickerPopoverContent = ({
   displayTwoCalendar,
   isSelectable,
   onChange,
-}: DateRangePickerProps & { desktop: boolean; displayTwoCalendar: boolean }) => {
+}: DateRangePickerPopoverContentProps) => {
   const isFirstMount = useFirstMountState();
   const [periods, setPeriods] = useState(() => {
     const startYearMonth = getYearMonth(value.start, format).getWithDefault(getTodayYearMonth());
@@ -1140,6 +1157,8 @@ export const DateRangePicker = ({
   value,
   error,
   format,
+  startLabel,
+  endLabel,
   firstWeekDay,
   monthNames,
   weekDayNames,
@@ -1168,37 +1187,53 @@ export const DateRangePicker = ({
 
   return (
     <View>
-      <Box direction="row" alignItems="center">
-        <Rifm value={value.start} onChange={handleStartChange} {...rifmDateProps}>
-          {({ value, onChange }) => (
-            <LakeTextInput
-              ref={ref}
-              placeholder={format}
-              value={value}
-              onChange={onChange}
-              error={error}
-              hideErrors={true}
-              ariaExpanded={isOpened}
-            />
+      <Box direction="row" alignItems="end">
+        <LakeLabel
+          label={startLabel}
+          style={styles.label}
+          render={() => (
+            <Rifm value={value.start} onChange={handleStartChange} {...rifmDateProps}>
+              {({ value, onChange }) => (
+                <LakeTextInput
+                  ref={ref}
+                  placeholder={format}
+                  value={value}
+                  onChange={onChange}
+                  error={error}
+                  hideErrors={true}
+                  ariaExpanded={isOpened}
+                />
+              )}
+            </Rifm>
           )}
-        </Rifm>
+        />
 
         <Space width={12} />
-        <Icon name="arrow-right-filled" size={20} />
+
+        <Box style={styles.arrowContainer} justifyContent="center">
+          <Icon name="arrow-right-filled" size={20} />
+        </Box>
+
         <Space width={12} />
 
-        <Rifm value={value.end} onChange={handleEndChange} {...rifmDateProps}>
-          {({ value, onChange }) => (
-            <LakeTextInput
-              placeholder={format}
-              value={value}
-              onChange={onChange}
-              error={error}
-              hideErrors={true}
-              ariaExpanded={isOpened}
-            />
+        <LakeLabel
+          label={endLabel}
+          style={styles.label}
+          render={() => (
+            <Rifm value={value.end} onChange={handleEndChange} {...rifmDateProps}>
+              {({ value, onChange }) => (
+                <LakeTextInput
+                  placeholder={format}
+                  value={value}
+                  onChange={onChange}
+                  error={error}
+                  hideErrors={true}
+                  ariaExpanded={isOpened}
+                />
+              )}
+            </Rifm>
           )}
-        </Rifm>
+        />
 
         <Space width={12} />
         <LakeButton mode="secondary" icon="calendar-ltr-regular" size="small" onPress={open} />

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -381,10 +381,11 @@ const getNewDateRange = (
   selectedDate: DatePickerDate,
 ): DatePickerRange => {
   const { start, end } = currentRange;
+
+  // Handle initial selection
   if (start.isNone()) {
     return { start: Option.Some(selectedDate), end: Option.None() };
   }
-
   if (end.isNone()) {
     if (isDateAfter(selectedDate, start.value)) {
       return { start, end: Option.Some(selectedDate) };
@@ -393,10 +394,18 @@ const getNewDateRange = (
     return { start: Option.Some(selectedDate), end: currentRange.start };
   }
 
+  // Handle selection outside of the current range
+  if (isDateBefore(selectedDate, start.value)) {
+    return { start: Option.Some(selectedDate), end: currentRange.end };
+  }
+  if (isDateAfter(selectedDate, end.value)) {
+    return { start: currentRange.start, end: Option.Some(selectedDate) };
+  }
+
+  // We change the closest date to the new date
   const startDistance = computeDateDistanceInDays(start.value, selectedDate);
   const endDistance = computeDateDistanceInDays(end.value, selectedDate);
 
-  // If both dates are already selected, we change the closest one to the new date
   if (startDistance < endDistance) {
     return { start: Option.Some(selectedDate), end: currentRange.end };
   }

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -1,10 +1,11 @@
 import { Option } from "@swan-io/boxed";
 import dayjs from "dayjs";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { StyleSheet, View } from "react-native";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+import { StyleSheet, TextInput, View } from "react-native";
 import { Rifm } from "rifm";
 import { P, match } from "ts-pattern";
 import { colors, invariantColors, radii, spacings } from "../constants/design";
+import { useDisclosure } from "../hooks/useDisclosure";
 import { noop } from "../utils/function";
 import { isNotNullish, isNotNullishOrEmpty, isNullishOrEmpty } from "../utils/nullish";
 import { getRifmProps } from "../utils/rifm";
@@ -15,6 +16,7 @@ import { LakeButton } from "./LakeButton";
 import { Item, LakeSelect } from "./LakeSelect";
 import { LakeText } from "./LakeText";
 import { LakeTextInput } from "./LakeTextInput";
+import { Popover } from "./Popover";
 import { Pressable } from "./Pressable";
 import { Separator } from "./Separator";
 import { Space } from "./Space";
@@ -773,23 +775,51 @@ export const DatePicker = ({
   isSelectable,
   onChange,
 }: DatePickerProps) => {
+  const ref = useRef<TextInput>(null);
+  const [isOpened, { open, close }] = useDisclosure(false);
+  const popoverId = useId();
+
   return (
     <>
-      <Rifm value={value ?? ""} onChange={onChange} {...rifmDateProps}>
-        {({ value, onChange }) => (
-          <LakeTextInput placeholder={format} value={value} error={error} onChange={onChange} />
-        )}
-      </Rifm>
+      <Box direction="row">
+        <Rifm value={value ?? ""} onChange={onChange} {...rifmDateProps}>
+          {({ value, onChange }) => (
+            <LakeTextInput
+              ref={ref}
+              placeholder={format}
+              value={value}
+              error={error}
+              onChange={onChange}
+              ariaExpanded={isOpened}
+            />
+          )}
+        </Rifm>
 
-      <DatePickerPopover
-        value={value}
-        format={format}
-        firstWeekDay={firstWeekDay}
-        monthNames={monthNames}
-        weekDayNames={weekDayNames}
-        isSelectable={isSelectable}
-        onChange={onChange}
-      />
+        <Space width={12} />
+        <LakeButton mode="secondary" icon="calendar-ltr-regular" size="small" onPress={open} />
+      </Box>
+
+      <Popover
+        id={popoverId}
+        role="listbox"
+        onDismiss={close}
+        referenceRef={ref}
+        autoFocus={true}
+        returnFocus={false}
+        visible={isOpened}
+        underlay={false}
+        forcedMode="Dropdown"
+      >
+        <DatePickerPopover
+          value={value}
+          format={format}
+          firstWeekDay={firstWeekDay}
+          monthNames={monthNames}
+          weekDayNames={weekDayNames}
+          isSelectable={isSelectable}
+          onChange={onChange}
+        />
+      </Popover>
     </>
   );
 };

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -721,6 +721,7 @@ const MonthCalendar = ({
 };
 
 export type DatePickerProps = {
+  label: string;
   value?: string;
   error?: string;
   format: DateFormat;
@@ -729,6 +730,10 @@ export type DatePickerProps = {
   weekDayNames: WeekDayNames;
   isSelectable?: (date: DatePickerDate) => boolean;
   onChange: (date: string) => void;
+};
+
+type DatePickerPopoverContentProps = Except<DatePickerProps, "label" | "error"> & {
+  desktop: boolean;
 };
 
 const DatePickerPopoverContent = ({
@@ -740,7 +745,7 @@ const DatePickerPopoverContent = ({
   desktop,
   isSelectable,
   onChange,
-}: DatePickerProps & { desktop: boolean }) => {
+}: DatePickerPopoverContentProps) => {
   const [monthYear, setMonthYear] = useState(() =>
     getYearMonth(value, format).getWithDefault(getTodayYearMonth()),
   );
@@ -786,6 +791,7 @@ const DatePickerPopoverContent = ({
 };
 
 export const DatePicker = ({
+  label,
   value,
   error,
   format,
@@ -802,22 +808,28 @@ export const DatePicker = ({
 
   return (
     <>
-      <Box direction="row">
-        <Rifm value={value ?? ""} onChange={onChange} {...rifmDateProps}>
-          {({ value, onChange }) => (
-            <LakeTextInput
-              ref={ref}
-              placeholder={format}
-              value={value}
-              error={error}
-              onChange={onChange}
-              ariaExpanded={isOpened}
-            />
+      <Box direction="row" alignItems="end">
+        <LakeLabel
+          label={label}
+          style={styles.label}
+          actions={
+            <LakeButton mode="secondary" icon="calendar-ltr-regular" size="small" onPress={open} />
+          }
+          render={() => (
+            <Rifm value={value ?? ""} onChange={onChange} {...rifmDateProps}>
+              {({ value, onChange }) => (
+                <LakeTextInput
+                  ref={ref}
+                  placeholder={format}
+                  value={value}
+                  error={error}
+                  onChange={onChange}
+                  ariaExpanded={isOpened}
+                />
+              )}
+            </Rifm>
           )}
-        </Rifm>
-
-        <Space width={12} />
-        <LakeButton mode="secondary" icon="calendar-ltr-regular" size="small" onPress={open} />
+        />
       </Box>
 
       <Popover id={popoverId} role="dialog" onDismiss={close} referenceRef={ref} visible={isOpened}>
@@ -842,7 +854,6 @@ type DatePickerPopoverProps = DatePickerProps & {
   id?: string;
   visible: boolean;
   referenceRef: React.RefObject<unknown>;
-  inputLabel: string;
   cancelLabel: string;
   confirmLabel: string;
   onDissmiss: () => void;
@@ -860,7 +871,7 @@ export const DatePickerPopover = ({
   id,
   visible,
   referenceRef,
-  inputLabel,
+  label,
   cancelLabel,
   confirmLabel,
   onDissmiss,
@@ -896,7 +907,7 @@ export const DatePickerPopover = ({
     >
       <View style={desktop ? styles.popoverDesktop : styles.popover}>
         <LakeLabel
-          label={inputLabel}
+          label={label}
           render={() => (
             <Rifm value={localeValue ?? ""} onChange={setLocaleValue} {...rifmDateProps}>
               {({ value, onChange }) => (
@@ -955,7 +966,7 @@ export type DateRangePickerProps = {
 
 type DateRangePickerPopoverContentProps = Except<
   DateRangePickerProps,
-  "startLabel" | "endLabel"
+  "startLabel" | "endLabel" | "error"
 > & {
   desktop: boolean;
   displayTwoCalendar: boolean;

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -339,9 +339,13 @@ const isSelectedDate = (date: DatePickerDate, value: Option<DatePickerDate> | Da
   return match(value)
     .with(Option.pattern.Some(P.select()), value => isDateEquals(value, date))
     .with(Option.pattern.None, () => false)
-    .with(
-      P.when(isDateRange),
-      ({ start, end }) =>
+    .with(P.when(isDateRange), ({ start, end }) => {
+      // if range is invalid, we don't display any selection
+      if (start.isSome() && end.isSome() && isDateAfter(start.value, end.value)) {
+        return false;
+      }
+
+      return (
         start.match({
           Some: start => isDateEquals(start, date),
           None: () => false,
@@ -349,8 +353,9 @@ const isSelectedDate = (date: DatePickerDate, value: Option<DatePickerDate> | Da
         end.match({
           Some: end => isDateEquals(end, date),
           None: () => false,
-        }),
-    )
+        })
+      );
+    })
     .exhaustive();
 };
 
@@ -370,6 +375,10 @@ const getRangeIndicatorType = (
   const startDate = start.value;
   const endDate = end.value;
 
+  // no interval indicator if range is invalid
+  if (isDateAfter(startDate, endDate)) {
+    return "none";
+  }
   if (isDateEquals(startDate, endDate)) {
     return "none";
   }
@@ -1001,6 +1010,7 @@ export const DateRangePicker = ({
               placeholder={format}
               value={value}
               onChange={onChange}
+              error={error}
               hideErrors={true}
             />
           )}
@@ -1016,6 +1026,7 @@ export const DateRangePicker = ({
               placeholder={format}
               value={value}
               onChange={onChange}
+              error={error}
               hideErrors={true}
             />
           )}

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -53,6 +53,17 @@ const styles = StyleSheet.create({
   dayNumberSelected: {
     backgroundColor: colors.current[500],
   },
+  todayIndicator: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
+    width: 4,
+    height: 4,
+    marginHorizontal: "auto",
+    borderRadius: 2,
+    backgroundColor: colors.current[500],
+  },
 });
 
 const NB_DAYS_IN_WEEK = 7;
@@ -162,6 +173,15 @@ export const isInRangeDate =
       date.year <= maxYear
     );
   };
+
+const isDateToday = (date: DatePickerDate): boolean => {
+  const today = new Date();
+  return (
+    date.day === today.getDate() &&
+    date.month === today.getMonth() &&
+    date.year === today.getFullYear()
+  );
+};
 
 const getMonthDates = (month: number, year: number): DatePickerDate[] => {
   const aggregate = (acc: DatePickerDate[], date: Date): DatePickerDate[] => {
@@ -287,6 +307,11 @@ const MonthCalendar = ({
               Some: date => isSelectedDate(date, value),
               None: () => false,
             });
+            const isToday = date.match({
+              Some: date => isDateToday(date),
+              None: () => false,
+            });
+
             return (
               <Pressable
                 key={dateIndex}
@@ -307,11 +332,15 @@ const MonthCalendar = ({
                       ? colors.current.contrast
                       : isDisabled
                       ? colors.gray[300]
+                      : isToday
+                      ? colors.current[500]
                       : colors.gray[900]
                   }
                 >
                   {date.match({ Some: ({ day }) => day.toString(), None: () => " " })}
                 </LakeText>
+
+                {isToday && <View style={styles.todayIndicator} />}
               </Pressable>
             );
           })}

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -815,11 +815,12 @@ export const DatePicker = ({
           actions={
             <LakeButton mode="secondary" icon="calendar-ltr-regular" size="small" onPress={open} />
           }
-          render={() => (
+          render={id => (
             <Rifm value={value ?? ""} onChange={onChange} {...rifmDateProps}>
               {({ value, onChange }) => (
                 <LakeTextInput
                   ref={ref}
+                  id={id}
                   placeholder={format}
                   value={value}
                   error={error}
@@ -908,10 +909,11 @@ export const DatePickerPopover = ({
       <View style={desktop ? styles.popoverDesktop : styles.popover}>
         <LakeLabel
           label={label}
-          render={() => (
+          render={id => (
             <Rifm value={localeValue ?? ""} onChange={setLocaleValue} {...rifmDateProps}>
               {({ value, onChange }) => (
                 <LakeTextInput
+                  id={id}
                   placeholder={format}
                   value={value}
                   error={error}
@@ -1202,11 +1204,12 @@ export const DateRangePicker = ({
         <LakeLabel
           label={startLabel}
           style={styles.label}
-          render={() => (
+          render={id => (
             <Rifm value={value.start} onChange={handleStartChange} {...rifmDateProps}>
               {({ value, onChange }) => (
                 <LakeTextInput
                   ref={ref}
+                  id={id}
                   placeholder={format}
                   value={value}
                   onChange={onChange}
@@ -1230,10 +1233,11 @@ export const DateRangePicker = ({
         <LakeLabel
           label={endLabel}
           style={styles.label}
-          render={() => (
+          render={id => (
             <Rifm value={value.end} onChange={handleEndChange} {...rifmDateProps}>
               {({ value, onChange }) => (
                 <LakeTextInput
+                  id={id}
                   placeholder={format}
                   value={value}
                   onChange={onChange}
@@ -1353,10 +1357,11 @@ export const DateRangePickerPopover = ({
             <LakeLabel
               label={startLabel}
               style={styles.label}
-              render={() => (
+              render={id => (
                 <Rifm value={localeValue.start} onChange={handleStartChange} {...rifmDateProps}>
                   {({ value, onChange }) => (
                     <LakeTextInput
+                      id={id}
                       placeholder={format}
                       value={value}
                       onChange={onChange}
@@ -1379,10 +1384,11 @@ export const DateRangePickerPopover = ({
             <LakeLabel
               label={endLabel}
               style={styles.label}
-              render={() => (
+              render={id => (
                 <Rifm value={localeValue.end} onChange={handleEndChange} {...rifmDateProps}>
                   {({ value, onChange }) => (
                     <LakeTextInput
+                      id={id}
                       placeholder={format}
                       value={value}
                       onChange={onChange}

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -170,6 +170,23 @@ const stringifyDate = (value: DatePickerDate, format: DateFormat): string => {
   return date.format(format);
 };
 
+export const validateDateRangeOrder = (
+  value: { start: string; end: string },
+  format: DateFormat,
+) => {
+  const range = parseRange(value, format);
+
+  if (range.start.isNone() || range.end.isNone()) {
+    return true;
+  }
+
+  if (isDateAfter(range.start.value, range.end.value)) {
+    return false;
+  }
+
+  return true;
+};
+
 const range = (start: number, end: number): number[] => {
   const result = [];
   for (let i = start; i <= end; i++) {
@@ -982,7 +999,7 @@ export const DateRangePicker = ({
   );
 
   return (
-    <>
+    <View>
       <Box direction="row" alignItems="center">
         <Rifm value={value.start} onChange={handleStartChange} {...rifmDateProps}>
           {({ value, onChange }) => (
@@ -1011,6 +1028,8 @@ export const DateRangePicker = ({
         </Rifm>
       </Box>
 
+      <Space height={4} />
+
       <LakeText variant="smallRegular" color={colors.negative[500]}>
         {error ?? " "}
       </LakeText>
@@ -1028,6 +1047,6 @@ export const DateRangePicker = ({
         cancelLabel={cancelLabel}
         confirmLabel={confirmLabel}
       />
-    </>
+    </View>
   );
 };

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -166,7 +166,7 @@ const parseRange = (value: { start: string; end: string }, format: DateFormat): 
 };
 
 const stringifyDate = (value: DatePickerDate, format: DateFormat): string => {
-  const date = dayjs.utc().date(value.day).month(value.month).year(value.year);
+  const date = dayjs.utc().year(value.year).month(value.month).date(value.day);
   return date.format(format);
 };
 
@@ -623,7 +623,7 @@ const MonthCalendar = ({
             });
 
             return (
-              <View style={styles.dayContainer}>
+              <View key={dateIndex} style={styles.dayContainer}>
                 {rangeIndicator !== "none" && (
                   <View
                     style={[
@@ -635,7 +635,6 @@ const MonthCalendar = ({
                 )}
 
                 <Pressable
-                  key={dateIndex}
                   disabled={isDisabled}
                   onPress={() => date.match({ Some: onChange, None: noop })}
                   style={({ focused, hovered, pressed }) => [

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -30,9 +30,6 @@ const styles = StyleSheet.create({
   popoverDesktop: {
     padding: spacings[24],
   },
-  calendarContainer: {
-    minWidth: 264, // value to fit with 320 width screen
-  },
   rangeCalendarContainer: {
     backgroundColor: invariantColors.white,
     borderRadius: radii[8],
@@ -758,7 +755,7 @@ const DatePickerPopoverContent = ({
   );
 
   return (
-    <View style={styles.calendarContainer}>
+    <>
       <YearMonthSelect
         monthNames={monthNames}
         value={monthYear}
@@ -777,11 +774,11 @@ const DatePickerPopoverContent = ({
         isSelectable={isSelectable}
         onChange={handleChange}
       />
-    </View>
+    </>
   );
 };
 
-const DATE_PICKER_MOBILE_THRESHOLD = 450;
+const DATE_PICKER_MOBILE_THRESHOLD = 400;
 
 export const DatePicker = ({
   value,
@@ -818,14 +815,7 @@ export const DatePicker = ({
         <LakeButton mode="secondary" icon="calendar-ltr-regular" size="small" onPress={open} />
       </Box>
 
-      <Popover
-        id={popoverId}
-        role="dialog"
-        onDismiss={close}
-        referenceRef={ref}
-        visible={isOpened}
-        forcedMode="Dropdown"
-      >
+      <Popover id={popoverId} role="dialog" onDismiss={close} referenceRef={ref} visible={isOpened}>
         <View style={desktop ? styles.popoverDesktop : styles.popover}>
           <DatePickerPopoverContent
             value={value}
@@ -870,6 +860,7 @@ export const DatePickerPopover = ({
   confirmLabel,
   onDissmiss,
 }: DatePickerPopoverProps) => {
+  const { desktop } = useResponsive(DATE_PICKER_MOBILE_THRESHOLD);
   const [localeValue, setLocaleValue] = useState(value);
 
   useEffect(() => {
@@ -898,7 +889,7 @@ export const DatePickerPopover = ({
       returnFocus={false}
       visible={visible}
     >
-      <View style={styles.popover}>
+      <View style={desktop ? styles.popoverDesktop : styles.popover}>
         <LakeLabel
           label={inputLabel}
           render={() => (
@@ -921,6 +912,7 @@ export const DatePickerPopover = ({
           firstWeekDay={firstWeekDay}
           monthNames={monthNames}
           weekDayNames={weekDayNames}
+          desktop={desktop}
           isSelectable={isSelectable}
           onChange={setLocaleValue}
         />

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -1,0 +1,451 @@
+import { Option } from "@swan-io/boxed";
+import dayjs from "dayjs";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { StyleSheet, View } from "react-native";
+import { Rifm } from "rifm";
+import { colors, invariantColors, radii, spacings } from "../constants/design";
+import { noop } from "../utils/function";
+import { isNotNullish, isNullish } from "../utils/nullish";
+import { getRifmProps } from "../utils/rifm";
+import { Box } from "./Box";
+import { Fill } from "./Fill";
+import { LakeButton } from "./LakeButton";
+import { Item, LakeSelect } from "./LakeSelect";
+import { LakeText } from "./LakeText";
+import { LakeTextInput } from "./LakeTextInput";
+import { Pressable } from "./Pressable";
+import { Space } from "./Space";
+
+const styles = StyleSheet.create({
+  popoverContainer: {
+    width: 430,
+    padding: spacings[24],
+    backgroundColor: invariantColors.white,
+    borderRadius: radii[8],
+  },
+  monthSelect: {
+    width: 130,
+  },
+  yearSelect: {
+    width: 100,
+  },
+  weekRow: {
+    paddingVertical: spacings[4],
+  },
+  dayName: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dayNumber: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 16,
+  },
+  dayNumberFocused: {},
+  dayNumberHover: {
+    backgroundColor: colors.current[100],
+  },
+  dayNumberPressed: {},
+  dayNumberSelected: {
+    backgroundColor: colors.current[500],
+  },
+});
+
+const NB_DAYS_IN_WEEK = 7;
+
+type MonthNames = readonly [
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+];
+type WeekDayNames = readonly [string, string, string, string, string, string, string];
+
+const weekDayIndex = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+};
+
+export type DatePickerDate = {
+  day: number;
+  month: number;
+  year: number;
+};
+
+type DateFormat = "DD/MM/YYYY" | "MM/DD/YYYY";
+
+const rifmDateProps = getRifmProps({
+  accept: "numeric",
+  charMap: { 2: "/", 4: "/" },
+  maxLength: 8,
+});
+
+const parseDate = (value: string, format: DateFormat): Option<DatePickerDate> => {
+  const date = dayjs.utc(value, format);
+  return date.isValid()
+    ? Option.Some({ day: date.date(), month: date.month(), year: date.year() })
+    : Option.None();
+};
+
+const stringifyDate = (value: DatePickerDate, format: DateFormat): string => {
+  const date = dayjs.utc().date(value.day).month(value.month).year(value.year);
+  return date.format(format);
+};
+
+const range = (start: number, end: number): number[] => {
+  const result = [];
+  for (let i = start; i <= end; i++) {
+    result.push(i);
+  }
+  return result;
+};
+
+const groupEvery = <T,>(input: T[], groupSize: number): T[][] => {
+  const result = [];
+  const nbGroups = Math.ceil(input.length / groupSize);
+  for (let i = 0; i < nbGroups; i++) {
+    result.push(input.slice(i * groupSize, (i + 1) * groupSize));
+  }
+
+  return result;
+};
+
+const padEnd = <T,>(input: T[], length: number, value: T): T[] => {
+  const itemsToAppend = new Array(length - input.length).fill(value) as T[];
+  return [...input, ...itemsToAppend];
+};
+
+const getMonthDates = (month: number, year: number): DatePickerDate[] => {
+  const aggregate = (acc: DatePickerDate[], date: Date): DatePickerDate[] => {
+    const dateDay = date.getDate();
+    const dateMonth = date.getMonth();
+    const dateYear = date.getFullYear();
+
+    if (date.getMonth() !== month) {
+      return acc;
+    }
+
+    return aggregate(
+      [...acc, { day: dateDay, month: dateMonth, year: dateYear }],
+      new Date(year, month, dateDay + 1),
+    );
+  };
+
+  return aggregate([], new Date(year, month, 1));
+};
+
+const getMonthWeeks = (
+  month: number,
+  year: number,
+  firstWeekDay: keyof typeof weekDayIndex,
+): Option<DatePickerDate>[][] => {
+  const firstWeekDayIndex = weekDayIndex[firstWeekDay];
+  const monthFirstWeekDay = new Date(year, month, 1).getDay();
+  const monthDates = getMonthDates(month, year).map(date => Option.Some(date));
+
+  const nbDaysToPrepend =
+    monthFirstWeekDay >= firstWeekDayIndex
+      ? monthFirstWeekDay - firstWeekDayIndex
+      : NB_DAYS_IN_WEEK - firstWeekDayIndex + monthFirstWeekDay;
+
+  // TODO Fix this when first week day if monday
+  for (let i = 0; i < nbDaysToPrepend; i++) {
+    monthDates.unshift(Option.None());
+  }
+  const weeks = groupEvery(monthDates, NB_DAYS_IN_WEEK);
+  const lastWeek = weeks[weeks.length - 1];
+
+  if (!lastWeek) {
+    return weeks;
+  }
+  weeks[weeks.length - 1] = padEnd(lastWeek, NB_DAYS_IN_WEEK, Option.None());
+
+  return weeks;
+};
+
+const getWeekDayNames = (
+  dayNames: WeekDayNames,
+  firstWeekDay: keyof typeof weekDayIndex = "sunday",
+): WeekDayNames => {
+  const firstWeekDayIndex = weekDayIndex[firstWeekDay];
+  const firstWeekDayNames = dayNames.slice(firstWeekDayIndex);
+  const lastWeekDayNames = dayNames.slice(0, firstWeekDayIndex);
+
+  // @ts-expect-error
+  return [...firstWeekDayNames, ...lastWeekDayNames];
+};
+
+const isSelectedDate = (date: DatePickerDate, value: Option<DatePickerDate>) => {
+  return value.match({
+    Some: value => value.day === date.day && value.month === date.month && value.year === date.year,
+    None: () => false,
+  });
+};
+
+type MonthCalendarProps = {
+  month: number;
+  year: number;
+  value: Option<DatePickerDate>;
+  firstWeekDay: keyof typeof weekDayIndex;
+  weekDayNames: WeekDayNames;
+  onChange: (date: DatePickerDate) => void;
+};
+
+const MonthCalendar = ({
+  month,
+  year,
+  value,
+  firstWeekDay,
+  weekDayNames,
+  onChange,
+}: MonthCalendarProps) => {
+  const dayNames = useMemo(
+    () => getWeekDayNames(weekDayNames, firstWeekDay),
+    [weekDayNames, firstWeekDay],
+  );
+  const weeks = useMemo(
+    () => getMonthWeeks(month, year, firstWeekDay),
+    [month, year, firstWeekDay],
+  );
+
+  return (
+    <View>
+      <Box direction="row" alignItems="center" justifyContent="spaceAround" style={styles.weekRow}>
+        {dayNames.map(dayName => (
+          <View key={dayName} style={styles.dayName}>
+            <LakeText variant="medium" color={colors.gray[600]}>
+              {dayName.substring(0, 1)}
+            </LakeText>
+          </View>
+        ))}
+      </Box>
+
+      {weeks.map((week, weekIndex) => (
+        <Box
+          key={weekIndex}
+          direction="row"
+          alignItems="center"
+          justifyContent="spaceAround"
+          style={styles.weekRow}
+        >
+          {week.map((date, dateIndex) => {
+            const isSelected = date.match({
+              Some: date => isSelectedDate(date, value),
+              None: () => false,
+            });
+            return (
+              <Pressable
+                key={dateIndex}
+                disabled={date.isNone()}
+                onPress={() => date.match({ Some: onChange, None: noop })}
+                style={({ focused, hovered, pressed }) => [
+                  styles.dayNumber,
+                  focused && styles.dayNumberFocused,
+                  hovered && styles.dayNumberHover,
+                  pressed && styles.dayNumberPressed,
+                  isSelected && styles.dayNumberSelected,
+                ]}
+              >
+                <LakeText
+                  variant="smallRegular"
+                  color={isSelected ? colors.current.contrast : colors.gray[900]}
+                >
+                  {date.match({ Some: ({ day }) => day.toString(), None: () => " " })}
+                </LakeText>
+              </Pressable>
+            );
+          })}
+        </Box>
+      ))}
+    </View>
+  );
+};
+
+export type DatePickerProps = {
+  value?: string;
+  format: DateFormat;
+  firstWeekDay: keyof typeof weekDayIndex;
+  monthNames: MonthNames;
+  weekDayNames: WeekDayNames;
+  onChange: (date: string) => void;
+};
+
+const DatePickerPopover = ({
+  value,
+  format,
+  firstWeekDay,
+  monthNames,
+  weekDayNames,
+  onChange,
+}: DatePickerProps) => {
+  const [{ month, year }, setMonthYear] = useState(() => {
+    if (isNullish(value)) {
+      return {
+        month: new Date().getMonth(),
+        year: new Date().getFullYear(),
+      };
+    }
+    const parsed = parseDate(value, format);
+    return parsed.match({
+      Some: ({ month, year }) => ({ month, year }),
+      None: () => ({
+        month: new Date().getMonth(),
+        year: new Date().getFullYear(),
+      }),
+    });
+  });
+
+  useEffect(() => {
+    if (isNullish(value)) {
+      return;
+    }
+    const parsed = parseDate(value, format);
+    if (parsed.isNone()) {
+      return;
+    }
+    const { month, year } = parsed.value;
+    setMonthYear({ month, year });
+  }, [value, format]);
+
+  const monthItems = useMemo<Item<number>[]>(
+    () => monthNames.map((name, index) => ({ name, value: index })),
+    [monthNames],
+  );
+
+  const yearItems = useMemo<Item<number>[]>(
+    () =>
+      range(year - 5, year + 5).map(year => ({
+        name: year.toString(),
+        value: year,
+      })),
+    [year],
+  );
+
+  const selectMonth = useCallback((month: number) => {
+    setMonthYear(({ year }) => ({ month, year }));
+  }, []);
+
+  const selectYear = useCallback((year: number) => {
+    setMonthYear(({ month }) => ({ month, year }));
+  }, []);
+
+  const setPreviousMonth = useCallback(() => {
+    setMonthYear(({ month, year }) => {
+      if (month === 0) {
+        return { month: 11, year: year - 1 };
+      }
+      return { month: month - 1, year };
+    });
+  }, []);
+
+  const setNextMonth = useCallback(() => {
+    setMonthYear(({ month, year }) => {
+      if (month === 11) {
+        return { month: 0, year: year + 1 };
+      }
+      return { month: month + 1, year };
+    });
+  }, []);
+
+  const handleChange = useCallback(
+    (date: DatePickerDate) => {
+      const formatted = stringifyDate(date, format);
+      onChange(formatted);
+    },
+    [format, onChange],
+  );
+
+  return (
+    <View style={styles.popoverContainer}>
+      <Box direction="row" alignItems="center">
+        <LakeSelect
+          items={monthItems}
+          value={month}
+          onValueChange={selectMonth}
+          mode="borderless"
+          size="small"
+          hideErrors={true}
+          style={styles.monthSelect}
+        />
+
+        <LakeSelect
+          items={yearItems}
+          value={year}
+          onValueChange={selectYear}
+          mode="borderless"
+          size="small"
+          hideErrors={true}
+          style={styles.yearSelect}
+        />
+
+        <Fill minWidth={12} />
+
+        <LakeButton
+          size="small"
+          mode="tertiary"
+          icon="arrow-left-filled"
+          onPress={setPreviousMonth}
+        />
+
+        <Space width={12} />
+        <LakeButton size="small" mode="tertiary" icon="arrow-right-filled" onPress={setNextMonth} />
+      </Box>
+
+      <Space height={24} />
+
+      <MonthCalendar
+        month={month}
+        year={year}
+        value={isNotNullish(value) ? parseDate(value, format) : Option.None()}
+        firstWeekDay={firstWeekDay}
+        weekDayNames={weekDayNames}
+        onChange={handleChange}
+      />
+    </View>
+  );
+};
+
+export const DatePicker = ({
+  value,
+  format,
+  firstWeekDay,
+  monthNames,
+  weekDayNames,
+  onChange,
+}: DatePickerProps) => {
+  return (
+    <>
+      <Rifm value={value ?? ""} onChange={onChange} {...rifmDateProps}>
+        {({ value, onChange }) => (
+          <LakeTextInput placeholder={format} value={value} onChange={onChange} />
+        )}
+      </Rifm>
+
+      <DatePickerPopover
+        value={value}
+        format={format}
+        firstWeekDay={firstWeekDay}
+        monthNames={monthNames}
+        weekDayNames={weekDayNames}
+        onChange={onChange}
+      />
+    </>
+  );
+};

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -811,6 +811,14 @@ const DateRangePickerPopover = ({
 
     if (startYearMonth.isSome()) {
       setPeriods(periods => {
+        const isStartAndEndSameMonth = isYearMonthEquals(startYearMonth.value, periods.end);
+        if (isStartAndEndSameMonth) {
+          return {
+            start: decrementYearMonth(periods.end),
+            end: periods.end,
+          };
+        }
+
         // change end period if it becomes before start period
         const endPeriod = maxYearMonth(periods.end, incrementYearMonth(startYearMonth.value));
 

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -794,8 +794,6 @@ export type DateRangePickerProps = {
   monthNames: MonthNames;
   weekDayNames: WeekDayNames;
   isSelectable?: (date: DatePickerDate) => boolean;
-  minDurationinDays?: number;
-  maxDurationinDays?: number;
   onChange: (date: { start: string; end: string }) => void;
   cancelLabel: string;
   confirmLabel: string;
@@ -808,8 +806,6 @@ const DateRangePickerPopover = ({
   monthNames,
   weekDayNames,
   isSelectable,
-  // minDurationinDays,
-  // maxDurationinDays,
   onChange,
   cancelLabel,
   confirmLabel,
@@ -978,8 +974,6 @@ export const DateRangePicker = ({
   monthNames,
   weekDayNames,
   isSelectable,
-  minDurationinDays,
-  maxDurationinDays,
   onChange,
   cancelLabel,
   confirmLabel,
@@ -1041,8 +1035,6 @@ export const DateRangePicker = ({
         monthNames={monthNames}
         weekDayNames={weekDayNames}
         isSelectable={isSelectable}
-        minDurationinDays={minDurationinDays}
-        maxDurationinDays={maxDurationinDays}
         onChange={onChange}
         cancelLabel={cancelLabel}
         confirmLabel={confirmLabel}

--- a/packages/lake/src/components/DatePicker.tsx
+++ b/packages/lake/src/components/DatePicker.tsx
@@ -849,14 +849,14 @@ const DateRangePickerPopover = ({
 
   const setStartPeriod = useCallback((yearMonth: YearMonth) => {
     setPeriods(periods => ({
-      ...periods,
       start: yearMonth,
+      end: maxYearMonth(periods.end, incrementYearMonth(yearMonth)),
     }));
   }, []);
 
   const setEndPeriod = useCallback((yearMonth: YearMonth) => {
     setPeriods(periods => ({
-      ...periods,
+      start: minYearMonth(periods.start, decrementYearMonth(yearMonth)),
       end: yearMonth,
     }));
   }, []);


### PR DESCRIPTION
This PR contains the new Date picker.  
As the file is pretty big and it might be hard to get into, here are the presentation of different parts:

## Exposed components

### 1️⃣ DatePicker
This one is the most basic we might use in forms to select 1 single date:  
![image](https://user-images.githubusercontent.com/32013054/234912313-c58695cc-2d3c-4beb-9570-33aceec7152a.png)

### 2️⃣ DatePickerPopover
This one is also for selecting 1 single date, but the input text is inside the popover, and the value is updated only when user click on `Select`. We might use this one for filters
![image](https://user-images.githubusercontent.com/32013054/234912767-ea0db346-29f3-410d-a749-0f589ebb32c8.png)

### 3️⃣ DateRangePicker
This component is for selecting a date range, there are 2 text inputs and when we click on the second button it opens a modal. This design was chosen because the range picker is large and we want to be sure we always have enough space to display it what ever page layout.
![image](https://user-images.githubusercontent.com/32013054/234913491-facba649-f006-4202-bb68-4aaec77ba7e9.png)
![image](https://user-images.githubusercontent.com/32013054/234913565-da7e86ba-320d-4829-ab37-f403af86db0d.png)

### 4️⃣ DateRangePickerModal
This one is also for range selection, but the text inputs are inside the modal and value is updated only on click on `Select`.  
![image](https://user-images.githubusercontent.com/32013054/234913962-2dc66894-de35-4703-96bd-24898dad9ce5.png)

## Exported helpers

### isTodayOrFutureDate
Can be usefull to create a date picker with only future dates selectable

### isDateInRange
Similar to `isTodayOrFutureDate` but to make only a range of days selectable

### validateDateRangeOrder
Can help to write `react-ux-form` validator to check start date is before end date while selecting a range

## Details about implementation

### YearMonthSelect
This component is for month/year selection with prev/next button displayed in a different way depending on some conditions:
- at right when there is 1 single month displayed
- around month and year selection when there are 2 months displayed (only for range selection on large screen)
- not displayed for small mobile
![image](https://user-images.githubusercontent.com/32013054/234915002-f08183a9-5389-4794-8cb7-9ba6e386cfe7.png)

### MonthCalendar component
This component displays the list of days for a month. Here is an example for April 2023:  
![image](https://user-images.githubusercontent.com/32013054/234914408-1bd361a3-28ed-436e-87b7-2cbf0439dc92.png)
