### PR TITLE
rename deprecated storybook exports

### DIFF
--- a/packages/lake/__stories__/Alert.stories.tsx
+++ b/packages/lake/__stories__/Alert.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { StyleSheet } from "react-native";
 import { LakeAlert } from "../src/components/LakeAlert";
 import { LakeButton } from "../src/components/LakeButton";
@@ -14,7 +14,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Informations/Alert",
   component: LakeAlert,
-} as ComponentMeta<typeof LakeAlert>;
+} as Meta<typeof LakeAlert>;
 
 export const Variants = () => {
   return (

--- a/packages/lake/__stories__/Avatar.stories.tsx
+++ b/packages/lake/__stories__/Avatar.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import dedent from "ts-dedent";
 import { Avatar } from "../src/components/Avatar";
 import { Box } from "../src/components/Box";
@@ -8,7 +8,7 @@ import { StoryBlock, StoryCodePart, StoryPart } from "./_StoriesComponents";
 export default {
   title: "Informations/Avatar",
   component: Avatar,
-} as ComponentMeta<typeof Avatar>;
+} as Meta<typeof Avatar>;
 
 export const Variants = () => {
   return (

--- a/packages/lake/__stories__/Box.stories.tsx
+++ b/packages/lake/__stories__/Box.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { StyleSheet, View } from "react-native";
 import { Box, BoxProps } from "../src/components/Box";
 import { Space } from "../src/components/Space";
@@ -29,7 +29,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Layout/Box",
   component: Box,
-} as ComponentMeta<typeof Box>;
+} as Meta<typeof Box>;
 
 type StoryArgs = Pick<BoxProps, "direction" | "alignItems" | "justifyContent">;
 

--- a/packages/lake/__stories__/Breadcrumbs.stories.tsx
+++ b/packages/lake/__stories__/Breadcrumbs.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { Box } from "../src/components/Box";
 import { Breadcrumbs, BreadcrumbsRoot, Crumb, useCrumb } from "../src/components/Breadcrumbs";
@@ -11,7 +11,7 @@ import { StoryBlock, StoryPart } from "./_StoriesComponents";
 export default {
   title: "Interactivity/Breadcrumbs",
   component: BreadcrumbsRoot,
-} as ComponentMeta<typeof BreadcrumbsRoot>;
+} as Meta<typeof BreadcrumbsRoot>;
 
 export const Variations = () => {
   return (

--- a/packages/lake/__stories__/Button.stories.tsx
+++ b/packages/lake/__stories__/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet } from "react-native";
 import { Except } from "type-fest";
@@ -27,7 +27,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Interactivity/Button",
   component: LakeButton,
-} as ComponentMeta<typeof LakeButton>;
+} as Meta<typeof LakeButton>;
 
 const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
 

--- a/packages/lake/__stories__/Checkbox.stories.tsx
+++ b/packages/lake/__stories__/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Except } from "type-fest";
@@ -20,7 +20,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Forms/Checkbox",
   component: LakeCheckbox,
-} as ComponentMeta<typeof LakeCheckbox>;
+} as Meta<typeof LakeCheckbox>;
 
 const InteractiveCheckbox = ({
   defaultValue = false,

--- a/packages/lake/__stories__/ChoicePicker.stories.tsx
+++ b/packages/lake/__stories__/ChoicePicker.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet } from "react-native";
 import { match } from "ts-pattern";
@@ -16,7 +16,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Forms/ChoicePicker",
   component: ChoicePicker,
-} as ComponentMeta<typeof ChoicePicker>;
+} as Meta<typeof ChoicePicker>;
 
 export const Default = () => {
   const items: ["Virtual", "VirtualAndPhysical", "SingleUseVirtual"] = [

--- a/packages/lake/__stories__/Combobox.stories.tsx
+++ b/packages/lake/__stories__/Combobox.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { AsyncData, Future, Result } from "@swan-io/boxed";
 import { useEffect, useState } from "react";
 import { StyleSheet } from "react-native";
@@ -17,7 +17,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Forms/Combobox",
   component: LakeCombobox,
-} as ComponentMeta<typeof LakeCombobox>;
+} as Meta<typeof LakeCombobox>;
 
 type ApiResponse = {
   products: ApiProduct[];

--- a/packages/lake/__stories__/CopyButton.stories.tsx
+++ b/packages/lake/__stories__/CopyButton.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useEffect, useState } from "react";
 import { StyleSheet } from "react-native";
 import { Box } from "../src/components/Box";
@@ -17,7 +17,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Interactivity/CopyButton",
   component: LakeCopyButton,
-} as ComponentMeta<typeof LakeCopyButton>;
+} as Meta<typeof LakeCopyButton>;
 
 const getTime = () => {
   const date = new Date();

--- a/packages/lake/__stories__/DownloadButton.stories.tsx
+++ b/packages/lake/__stories__/DownloadButton.stories.tsx
@@ -1,11 +1,11 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { LakeDownloadButton } from "../src/components/LakeDownloadButton";
 import { StoryBlock } from "./_StoriesComponents";
 
 export default {
   title: "Interactivity/DownloadButton",
   component: LakeDownloadButton,
-} as ComponentMeta<typeof LakeDownloadButton>;
+} as Meta<typeof LakeDownloadButton>;
 
 export const Default = () => {
   return (

--- a/packages/lake/__stories__/Filter.stories.tsx
+++ b/packages/lake/__stories__/Filter.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { View } from "react-native";
 import { FilterChooser } from "../src/components/FilterChooser";
@@ -93,7 +93,7 @@ const availableFilters: { name: keyof State; label: string }[] = [
 export default {
   title: "Forms/Filter",
   component: FilterChooser,
-} as ComponentMeta<typeof FilterChooser>;
+} as Meta<typeof FilterChooser>;
 
 export const All = () => {
   const [openFilters, setOpenFilters] = useState<(keyof State)[]>([]);

--- a/packages/lake/__stories__/FixedListView.stories.tsx
+++ b/packages/lake/__stories__/FixedListView.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { Meta, StoryFn } from "@storybook/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { v4 as uuid } from "uuid";
 import { Box } from "../src/components/Box";
@@ -23,7 +23,7 @@ import { Tag } from "../src/components/Tag";
 export default {
   title: "Layout/FixedListView",
   component: FixedListView,
-} as ComponentMeta<typeof FixedListView>;
+} as Meta<typeof FixedListView>;
 
 type TestRow = {
   id: string;
@@ -219,15 +219,15 @@ const EditableFixedListView = (props: Pick<FixedListViewProps<TestRow, SortInfo>
   );
 };
 
-export const Primary: ComponentStory<typeof FixedListView> = () => {
+export const Primary: StoryFn<typeof FixedListView> = () => {
   return <EditableFixedListView />;
 };
 
-export const WithoutBackground: ComponentStory<typeof FixedListView> = () => {
+export const WithoutBackground: StoryFn<typeof FixedListView> = () => {
   return <EditableFixedListView mode="plain" />;
 };
 
-export const Placeholder: ComponentStory<typeof FixedListView> = () => {
+export const Placeholder: StoryFn<typeof FixedListView> = () => {
   return (
     <FixedListViewPlaceholder rowHeight={48} rowVerticalSpacing={4} headerHeight={48} count={3} />
   );

--- a/packages/lake/__stories__/FlowPresentation.stories.tsx
+++ b/packages/lake/__stories__/FlowPresentation.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { FlowPresentation } from "../src/components/FlowPresentation";
 import { Space } from "../src/components/Space";
 import { WithCurrentColor } from "../src/components/WithCurrentColor";
@@ -7,7 +7,7 @@ import { StoryBlock, StoryPart } from "./_StoriesComponents";
 export default {
   title: "Informations/FlowPresentation",
   component: FlowPresentation,
-} as ComponentMeta<typeof FlowPresentation>;
+} as Meta<typeof FlowPresentation>;
 
 export const Default = () => {
   return (

--- a/packages/lake/__stories__/FullViewportLayer.stories.tsx
+++ b/packages/lake/__stories__/FullViewportLayer.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
 import { Box } from "../src/components/Box";
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Layout/FullViewportLayer",
   component: FullViewportLayer,
-} as ComponentMeta<typeof FullViewportLayer>;
+} as Meta<typeof FullViewportLayer>;
 
 export const Default = () => {
   const [visible, setVisible] = useState(false);

--- a/packages/lake/__stories__/Heading.stories.tsx
+++ b/packages/lake/__stories__/Heading.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { LakeHeading } from "../src/components/LakeHeading";
 import { Space } from "../src/components/Space";
 import { colors } from "../src/constants/design";
@@ -7,7 +7,7 @@ import { StoryBlock, StoryPart } from "./_StoriesComponents";
 export default {
   title: "Typography/Heading",
   component: LakeHeading,
-} as ComponentMeta<typeof LakeHeading>;
+} as Meta<typeof LakeHeading>;
 
 export const Variations = () => {
   return (

--- a/packages/lake/__stories__/Icon.stories.tsx
+++ b/packages/lake/__stories__/Icon.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet } from "react-native";
 import { BorderedIcon } from "../src/components/BorderedIcon";
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Informations/Icon",
   component: BorderedIcon,
-} as ComponentMeta<typeof BorderedIcon>;
+} as Meta<typeof BorderedIcon>;
 
 const getKeys = <T extends string>(obj: Record<T, unknown>): T[] => Object.keys(obj) as T[];
 

--- a/packages/lake/__stories__/Label.stories.tsx
+++ b/packages/lake/__stories__/Label.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { StyleSheet, Text, View } from "react-native";
 import { Grid } from "../src/components/Grid";
 import { LakeCopyButton } from "../src/components/LakeCopyButton";
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Forms/Label",
   component: LakeLabel,
-} as ComponentMeta<typeof LakeLabel>;
+} as Meta<typeof LakeLabel>;
 
 const label = "Creditor IBAN";
 export const ReadOnly = () => {

--- a/packages/lake/__stories__/Modal.stories.tsx
+++ b/packages/lake/__stories__/Modal.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { ScrollView, StyleSheet, View } from "react-native";
 import { Except } from "type-fest";
@@ -26,7 +26,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Layout/Modal",
   component: LakeModal,
-} as ComponentMeta<typeof LakeModal>;
+} as Meta<typeof LakeModal>;
 
 type ButtonModalProps = Except<LakeModalProps, "children" | "visible"> & {
   withCloseCross?: boolean;

--- a/packages/lake/__stories__/MultiSelect.stories.tsx
+++ b/packages/lake/__stories__/MultiSelect.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet } from "react-native";
 import { Except } from "type-fest";
@@ -15,7 +15,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Forms/MultiSelect",
   component: MultiSelect,
-} as ComponentMeta<typeof MultiSelect>;
+} as Meta<typeof MultiSelect>;
 
 const items: MultiSelectItem[] = [
   { label: "Camille", value: "camille", group: "C" },

--- a/packages/lake/__stories__/PlainListView.stories.tsx
+++ b/packages/lake/__stories__/PlainListView.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { Meta, StoryFn } from "@storybook/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { v4 as uuid } from "uuid";
 import { Box } from "../src/components/Box";
@@ -13,7 +13,7 @@ import { Tag } from "../src/components/Tag";
 export default {
   title: "Layout/PlainListView",
   component: PlainListView,
-} as ComponentMeta<typeof PlainListView>;
+} as Meta<typeof PlainListView>;
 
 type TestRow = {
   id: string;
@@ -62,7 +62,7 @@ const generateItem = (index: number): TestRow => {
   };
 };
 
-export const Primary: ComponentStory<typeof PlainListView> = () => {
+export const Primary: StoryFn<typeof PlainListView> = () => {
   const [sort, setSort] = useState<SortInfo>({ key: "name", order: "Desc" });
   const [endReachedTimes, setEndReachedTimes] = useState(0);
   const [withInfiniteScroll, setWithInfiniteScroll] = useState(false);

--- a/packages/lake/__stories__/Radio.stories.tsx
+++ b/packages/lake/__stories__/Radio.stories.tsx
@@ -1,11 +1,11 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { LakeRadio } from "../src/components/LakeRadio";
 import { StoryBlock, StoryPart } from "./_StoriesComponents";
 
 export default {
   title: "Forms/Radio",
   component: LakeRadio,
-} as ComponentMeta<typeof LakeRadio>;
+} as Meta<typeof LakeRadio>;
 
 export const Variations = () => {
   return (

--- a/packages/lake/__stories__/RadioGroup.stories.tsx
+++ b/packages/lake/__stories__/RadioGroup.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { Except } from "type-fest";
 import { RadioGroup, RadioGroupItem, RadioGroupProps } from "../src/components/RadioGroup";
@@ -7,7 +7,7 @@ import { StoryBlock, StoryPart } from "./_StoriesComponents";
 export default {
   title: "Forms/RadioGroup",
   component: RadioGroup,
-} as ComponentMeta<typeof RadioGroup>;
+} as Meta<typeof RadioGroup>;
 
 function EditableRadioGroup<T>(props: Except<RadioGroupProps<T>, "value" | "onValueChange">) {
   const [value, setValue] = useState<T>();

--- a/packages/lake/__stories__/ReadonlyFieldList.stories.tsx
+++ b/packages/lake/__stories__/ReadonlyFieldList.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { LakeCopyButton } from "../src/components/LakeCopyButton";
 import { LakeLabel } from "../src/components/LakeLabel";
 import { LakeText } from "../src/components/LakeText";
@@ -10,7 +10,7 @@ import { StoryBlock } from "./_StoriesComponents";
 export default {
   title: "Forms/ReadOnlyFieldList",
   component: ReadOnlyFieldList,
-} as ComponentMeta<typeof ReadOnlyFieldList>;
+} as Meta<typeof ReadOnlyFieldList>;
 
 export const Default = () => {
   return (

--- a/packages/lake/__stories__/ResponsiveContainer.stories.tsx
+++ b/packages/lake/__stories__/ResponsiveContainer.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Box } from "../src/components/Box";
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Layout/ResponsiveContainer",
   component: ResponsiveContainer,
-} as ComponentMeta<typeof ResponsiveContainer>;
+} as Meta<typeof ResponsiveContainer>;
 
 export const Default = () => {
   const [forceMobileWidth, setForceMobileWidth] = useState(false);

--- a/packages/lake/__stories__/RightPanel.stories.tsx
+++ b/packages/lake/__stories__/RightPanel.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Box } from "../src/components/Box";
@@ -38,7 +38,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Layout/RightPanel",
   component: RightPanel,
-} as ComponentMeta<typeof RightPanel>;
+} as Meta<typeof RightPanel>;
 
 export const Default = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/packages/lake/__stories__/ScrollView.stories.tsx
+++ b/packages/lake/__stories__/ScrollView.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { StyleSheet, View } from "react-native";
 import { LakeScrollView } from "../src/components/LakeScrollView";
 import { LakeText } from "../src/components/LakeText";
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Layout/ScrollView",
   component: LakeScrollView,
-} as ComponentMeta<typeof LakeScrollView>;
+} as Meta<typeof LakeScrollView>;
 
 export const Default = () => {
   return (

--- a/packages/lake/__stories__/SearchField.stories.tsx
+++ b/packages/lake/__stories__/SearchField.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet } from "react-native";
 import { LakeSearchField } from "../src/components/LakeSearchField";
@@ -15,7 +15,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Forms/SearchField",
   component: LakeSearchField,
-} as ComponentMeta<typeof LakeSearchField>;
+} as Meta<typeof LakeSearchField>;
 
 export const Variations = () => {
   const [text1, setText1] = useState<string>();

--- a/packages/lake/__stories__/Select.stories.tsx
+++ b/packages/lake/__stories__/Select.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { Meta, StoryFn } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet } from "react-native";
 import { Except } from "type-fest";
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Forms/Select",
   component: LakeSelect,
-} as ComponentMeta<typeof LakeSelect>;
+} as Meta<typeof LakeSelect>;
 
 const items = [
   { name: "Camille", value: 1 },
@@ -63,7 +63,7 @@ const EditableSelect = ({
   );
 };
 
-export const Variations: ComponentStory<typeof LakeSelect> = () => {
+export const Variations: StoryFn<typeof LakeSelect> = () => {
   return (
     <StoryBlock title="Select variations">
       <StoryPart title="Default">

--- a/packages/lake/__stories__/Separator.stories.tsx
+++ b/packages/lake/__stories__/Separator.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { StyleSheet, View } from "react-native";
 import { Box } from "../src/components/Box";
 import { Separator } from "../src/components/Separator";
@@ -17,7 +17,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Layout/Separator",
   component: Separator,
-} as ComponentMeta<typeof Separator>;
+} as Meta<typeof Separator>;
 
 export const Directions = () => {
   return (

--- a/packages/lake/__stories__/SidebarNavigationTracker.stories.tsx
+++ b/packages/lake/__stories__/SidebarNavigationTracker.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { Pressable, StyleSheet } from "react-native";
 import { Box } from "../src/components/Box";
@@ -23,7 +23,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Interactivity/SidebarNavigationTracker",
   component: SidebarNavigationTracker,
-} as ComponentMeta<typeof SidebarNavigationTracker>;
+} as Meta<typeof SidebarNavigationTracker>;
 
 const generateInterval = (start: number, end: number) =>
   new Array(end - start + 1).fill(0).map((_, index) => start + index);

--- a/packages/lake/__stories__/Slider.stories.tsx
+++ b/packages/lake/__stories__/Slider.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Except } from "type-fest";
@@ -18,7 +18,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Forms/Slider",
   component: LakeSlider,
-} as ComponentMeta<typeof LakeSlider>;
+} as Meta<typeof LakeSlider>;
 
 const EditableSlider = ({
   mobileSize = false,

--- a/packages/lake/__stories__/SortBottomPanel.stories.tsx
+++ b/packages/lake/__stories__/SortBottomPanel.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet } from "react-native";
 import { LakeButton } from "../src/components/LakeButton";
@@ -16,7 +16,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Forms/SortBottomPanel",
   component: SortBottomPanel,
-} as ComponentMeta<typeof SortBottomPanel>;
+} as Meta<typeof SortBottomPanel>;
 
 type FieldName = "status" | "type" | "amount" | "executionDate";
 

--- a/packages/lake/__stories__/Stepper.stories.tsx
+++ b/packages/lake/__stories__/Stepper.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { match, P } from "ts-pattern";
 import { Box } from "../src/components/Box";
@@ -12,7 +12,7 @@ import { StoryBlock } from "./_StoriesComponents";
 export default {
   title: "Forms/Stepper",
   component: LakeStepper,
-} as ComponentMeta<typeof LakeStepper>;
+} as Meta<typeof LakeStepper>;
 
 const steps: TopLevelStep[] = [
   {

--- a/packages/lake/__stories__/SwanLogo.stories.tsx
+++ b/packages/lake/__stories__/SwanLogo.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { Space } from "../src/components/Space";
 import { SwanLogo } from "../src/components/SwanLogo";
 import { colors } from "../src/constants/design";
@@ -7,7 +7,7 @@ import { StoryBlock } from "./_StoriesComponents";
 export default {
   title: "Informations/SwanLogo",
   component: SwanLogo,
-} as ComponentMeta<typeof SwanLogo>;
+} as Meta<typeof SwanLogo>;
 
 export const Colors = () => {
   return (

--- a/packages/lake/__stories__/Switch.stories.tsx
+++ b/packages/lake/__stories__/Switch.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useCallback, useState } from "react";
 import { Box } from "../src/components/Box";
 import { LakeText } from "../src/components/LakeText";
@@ -10,7 +10,7 @@ import { StoryBlock, StoryPart } from "./_StoriesComponents";
 export default {
   title: "Forms/Switch",
   component: Switch,
-} as ComponentMeta<typeof Switch>;
+} as Meta<typeof Switch>;
 
 export const Default = () => {
   const [value, setValue] = useState<boolean>(true);

--- a/packages/lake/__stories__/TabView.stories.tsx
+++ b/packages/lake/__stories__/TabView.stories.tsx
@@ -1,11 +1,11 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { TabView } from "../src/components/TabView";
 import { StoryBlock } from "./_StoriesComponents";
 
 export default {
   title: "Interactivity/TabView",
   component: TabView,
-} as ComponentMeta<typeof TabView>;
+} as Meta<typeof TabView>;
 
 export const Default = () => {
   return (

--- a/packages/lake/__stories__/Text.stories.tsx
+++ b/packages/lake/__stories__/Text.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { LakeText } from "../src/components/LakeText";
 import { Space } from "../src/components/Space";
 import { colors } from "../src/constants/design";
@@ -7,7 +7,7 @@ import { StoryBlock, StoryPart } from "./_StoriesComponents";
 export default {
   title: "Typography/Text",
   component: LakeText,
-} as ComponentMeta<typeof LakeText>;
+} as Meta<typeof LakeText>;
 
 export const Variations = () => {
   return (

--- a/packages/lake/__stories__/TextInput.stories.tsx
+++ b/packages/lake/__stories__/TextInput.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Except } from "type-fest";
@@ -14,7 +14,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Forms/TextInput",
   component: LakeTextInput,
-} as ComponentMeta<typeof LakeTextInput>;
+} as Meta<typeof LakeTextInput>;
 
 const EditableInputText = (props: Except<LakeTextInputProps, "value" | "onChange">) => {
   const [value, setValue] = useState(props.defaultValue ?? "");

--- a/packages/lake/__stories__/Tile.stories.tsx
+++ b/packages/lake/__stories__/Tile.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { StyleSheet } from "react-native";
 import { Icon } from "../src/components/Icon";
 import { LakeAlert } from "../src/components/LakeAlert";
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Layout/Tile",
   component: Tile,
-} as ComponentMeta<typeof Tile>;
+} as Meta<typeof Tile>;
 
 export const Default = () => {
   return (

--- a/packages/lake/__stories__/TilePlaceholder.stories.tsx
+++ b/packages/lake/__stories__/TilePlaceholder.stories.tsx
@@ -1,11 +1,11 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { TileGridPlaceholder, TilePlaceholder } from "../src/components/TilePlaceholder";
 import { StoryBlock, StoryPart } from "./_StoriesComponents";
 
 export default {
   title: "Layout/TilePlaceholder",
   component: TilePlaceholder,
-} as ComponentMeta<typeof TilePlaceholder>;
+} as Meta<typeof TilePlaceholder>;
 
 export const Default = () => {
   return (

--- a/packages/lake/__stories__/Toast.stories.tsx
+++ b/packages/lake/__stories__/Toast.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { LakeButton } from "../src/components/LakeButton";
 import { Space } from "../src/components/Space";
 import { ToastStack } from "../src/components/ToastStack";
@@ -14,7 +14,7 @@ const styles = {
 export default {
   title: "Interactivity/Toast",
   component: ToastStack,
-} as ComponentMeta<typeof ToastStack>;
+} as Meta<typeof ToastStack>;
 
 export const Default = () => {
   return (

--- a/packages/lake/__stories__/Tooltip.stories.tsx
+++ b/packages/lake/__stories__/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { StyleSheet } from "react-native";
 import { Box } from "../src/components/Box";
 import { LakeText } from "../src/components/LakeText";
@@ -19,7 +19,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Interactivity/Tooltip",
   component: LakeTooltip,
-} as ComponentMeta<typeof LakeTooltip>;
+} as Meta<typeof LakeTooltip>;
 
 export const Placements = () => {
   return (

--- a/packages/lake/__stories__/TransitionGroupView.stories.tsx
+++ b/packages/lake/__stories__/TransitionGroupView.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Box } from "../src/components/Box";
@@ -40,7 +40,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Animations/TransitionGroupView",
   component: TransitionGroupView,
-} as ComponentMeta<typeof TransitionGroupView>;
+} as Meta<typeof TransitionGroupView>;
 
 export const Default = () => {
   const [items, setItems] = useState<string[]>([]);

--- a/packages/lake/__stories__/TransitionView.stories.tsx
+++ b/packages/lake/__stories__/TransitionView.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Box } from "../src/components/Box";
@@ -44,7 +44,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Animations/TransitionView",
   component: TransitionView,
-} as ComponentMeta<typeof TransitionView>;
+} as Meta<typeof TransitionView>;
 
 export const Default = () => {
   const [showBlock, setShowBlock] = useState(false);

--- a/packages/lake/__stories__/UploadArea.stories.tsx
+++ b/packages/lake/__stories__/UploadArea.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { UploadArea, UploadFileStatus } from "@swan-io/shared-business/src/components/UploadArea";
 import { useState } from "react";
 import { StyleSheet } from "react-native";
@@ -15,7 +15,7 @@ const ACCEPTED_FORMATS = ["application/pdf", "image/png", "image/jpeg"];
 export default {
   title: "Forms/UploadArea",
   component: UploadArea,
-} as ComponentMeta<typeof UploadArea>;
+} as Meta<typeof UploadArea>;
 
 type StoryArgs = {
   layout: "vertical" | "horizontal";

--- a/packages/lake/__stories__/WithCurrentColor.stories.tsx
+++ b/packages/lake/__stories__/WithCurrentColor.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { StyleSheet, View } from "react-native";
 import { Box } from "../src/components/Box";
 import { WithCurrentColor } from "../src/components/WithCurrentColor";
@@ -25,7 +25,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Utilities/WithCurrentColor",
   component: WithCurrentColor,
-} as ComponentMeta<typeof WithCurrentColor>;
+} as Meta<typeof WithCurrentColor>;
 
 export const Colors = () => {
   return (

--- a/packages/lake/__stories__/WithPartnerAccentColor.stories.tsx
+++ b/packages/lake/__stories__/WithPartnerAccentColor.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import { StyleSheet, View } from "react-native";
 import { Box } from "../src/components/Box";
 import { WithPartnerAccentColor } from "../src/components/WithPartnerAccentColor";
@@ -20,7 +20,7 @@ const styles = StyleSheet.create({
 export default {
   title: "Utilities/WithPartnerAccentColor",
   component: WithPartnerAccentColor,
-} as ComponentMeta<typeof WithPartnerAccentColor>;
+} as Meta<typeof WithPartnerAccentColor>;
 
 type StoryArgs = {
   color: string;


### PR DESCRIPTION
In storybook v7:
- `ComponentMeta` is deprecated and becomes `Meta`
- `ComponentStory` is deprecated and becomes `StoryFn`
