### PR TITLE
show invalid fields on UBO form mount

### DIFF
--- a/packages/shared-business/src/components/BeneficiaryForm.tsx
+++ b/packages/shared-business/src/components/BeneficiaryForm.tsx
@@ -386,25 +386,10 @@ export const BeneficiaryForm = forwardRef<BeneficiaryFormRef | undefined, Props>
 
     useEffect(() => {
       if (initialState != null) {
-        // validate all fields on mount to display errors on edition open
-        Promise.all([
-          validateField("firstName"),
-          validateField("lastName"),
-          validateField("birthDate"),
-          validateField("birthCountryCode"),
-          validateField("birthCity"),
-          validateField("birthCityPostalCode"),
-          validateField("type"),
-          validateField("capitalType"),
-          validateField("totalCapitalPercentage"),
-          validateField("address"),
-          validateField("city"),
-          validateField("postalCode"),
-          validateField("country"),
-          validateField("taxIdentificationNumber"),
-        ]).catch(noop);
+        // submit form to validate all fields
+        submitForm(noop);
       }
-    }, [initialState, validateField]);
+    }, [initialState, submitForm]);
 
     useEffect(() => {
       return listenFields(["type"], () => {

--- a/packages/shared-business/src/components/BeneficiaryForm.tsx
+++ b/packages/shared-business/src/components/BeneficiaryForm.tsx
@@ -385,6 +385,28 @@ export const BeneficiaryForm = forwardRef<BeneficiaryFormRef | undefined, Props>
     const hasBeenSubmittedOnce = useRef(false);
 
     useEffect(() => {
+      if (initialState != null) {
+        // validate all fields on mount to display errors on edition open
+        Promise.all([
+          validateField("firstName"),
+          validateField("lastName"),
+          validateField("birthDate"),
+          validateField("birthCountryCode"),
+          validateField("birthCity"),
+          validateField("birthCityPostalCode"),
+          validateField("type"),
+          validateField("capitalType"),
+          validateField("totalCapitalPercentage"),
+          validateField("address"),
+          validateField("city"),
+          validateField("postalCode"),
+          validateField("country"),
+          validateField("taxIdentificationNumber"),
+        ]).catch(noop);
+      }
+    }, [initialState, validateField]);
+
+    useEffect(() => {
       return listenFields(["type"], () => {
         if (hasBeenSubmittedOnce.current) {
           // The setTimeout is needed here so that the `validateField`


### PR DESCRIPTION
On the onboarding, when there is an invalid UBO and open it, we don't where the error come from.  
This PR adds auto validation on UBO form only when we edit it. So the user will be able to see directly what are invalid fields