### PR TITLE
add ellipsis style in SimpleTitleCell

### DIFF
--- a/packages/lake/src/components/FixedListViewCells.tsx
+++ b/packages/lake/src/components/FixedListViewCells.tsx
@@ -194,11 +194,9 @@ export const SimpleTitleCell = ({
   <View style={styles.cell}>
     <LakeText
       numberOfLines={1}
-      color={colors.gray[900]}
+      color={isHighlighted ? colors.current.primary : colors.gray[900]}
+      style={styles.regularText}
       variant="medium"
-      {...(isHighlighted && {
-        color: colors.current.primary,
-      })}
     >
       {text}
     </LakeText>


### PR DESCRIPTION
This PR adds ellipsis in `SimpleTitleCell` component. 

Before:
![image](https://github.com/swan-io/lake/assets/32013054/fc166f3a-2610-4c6a-ac19-cc8a0a662203)


After:
![image](https://github.com/swan-io/lake/assets/32013054/c8b48908-daba-4102-9f87-7ad4ec4d7366)
