### PR TITLE
change QuickActions API

### DIFF
--- a/packages/lake/__stories__/QuickActions.stories.tsx
+++ b/packages/lake/__stories__/QuickActions.stories.tsx
@@ -24,7 +24,18 @@ const actions: QuickAction[] = [
   {
     icon: "document-regular",
     label: "Document",
+    tooltipText: "Add a new document",
     disabled: true,
+    onPress: () => console.log("Click on Document"),
+    backgroundColor: colors.live.primary,
+    color: colors.live.contrast,
+  },
+  {
+    icon: "document-regular",
+    label: "Document",
+    tooltipText: "Add a new document",
+    tooltipDisabled: true,
+    disabled: false,
     onPress: () => console.log("Click on Document"),
     backgroundColor: colors.live.primary,
     color: colors.live.contrast,
@@ -42,24 +53,8 @@ const actions: QuickAction[] = [
 export const Default = () => {
   return (
     <StoryBlock title="QuickActions">
-      <StoryPart title="Without any action">
-        <QuickActions actions={[]} />
-      </StoryPart>
-
-      <StoryPart title="Without 1 action">
-        <QuickActions actions={actions.slice(0, 1)} />
-      </StoryPart>
-
-      <StoryPart title="Without several actions">
+      <StoryPart title="With several actions">
         <QuickActions actions={actions} />
-      </StoryPart>
-
-      <StoryPart title="With tooltip">
-        <QuickActions actions={actions} tooltipText="Actions" />
-      </StoryPart>
-
-      <StoryPart title="With tooltip disabled">
-        <QuickActions actions={actions} tooltipText="Actions" tooltipDisabled={true} />
       </StoryPart>
     </StoryBlock>
   );

--- a/packages/lake/__stories__/QuickActions.stories.tsx
+++ b/packages/lake/__stories__/QuickActions.stories.tsx
@@ -1,0 +1,66 @@
+import { Meta } from "@storybook/react";
+import { QuickAction, QuickActions } from "../src/components/QuickActions";
+import { colors } from "../src/constants/design";
+import { StoryBlock, StoryPart } from "./_StoriesComponents";
+
+export default {
+  title: "Interactivity/QuickActions",
+  component: QuickActions,
+} as Meta<typeof QuickActions>;
+
+const actions: QuickAction[] = [
+  {
+    icon: "building-bank-regular",
+    label: "Bank",
+    onPress: () => console.log("Click on Bank"),
+  },
+  {
+    icon: "database-regular",
+    label: "Database",
+    onPress: () => console.log("Click on Database"),
+    backgroundColor: colors.positive.primary,
+    color: colors.positive.contrast,
+  },
+  {
+    icon: "document-regular",
+    label: "Document",
+    disabled: true,
+    onPress: () => console.log("Click on Document"),
+    backgroundColor: colors.live.primary,
+    color: colors.live.contrast,
+  },
+  {
+    icon: "desktop-regular",
+    label: "Desktop",
+    onPress: () => console.log("Click on Desktop"),
+    isLoading: true,
+    backgroundColor: colors.sandbox.primary,
+    color: colors.sandbox.contrast,
+  },
+];
+
+export const Default = () => {
+  return (
+    <StoryBlock title="QuickActions">
+      <StoryPart title="Without any action">
+        <QuickActions actions={[]} />
+      </StoryPart>
+
+      <StoryPart title="Without 1 action">
+        <QuickActions actions={actions.slice(0, 1)} />
+      </StoryPart>
+
+      <StoryPart title="Without several actions">
+        <QuickActions actions={actions} />
+      </StoryPart>
+
+      <StoryPart title="With tooltip">
+        <QuickActions actions={actions} tooltipText="Actions" />
+      </StoryPart>
+
+      <StoryPart title="With tooltip disabled">
+        <QuickActions actions={actions} tooltipText="Actions" tooltipDisabled={true} />
+      </StoryPart>
+    </StoryBlock>
+  );
+};

--- a/packages/lake/src/components/QuickActions.tsx
+++ b/packages/lake/src/components/QuickActions.tsx
@@ -42,6 +42,8 @@ const styles = StyleSheet.create({
 export type QuickAction = {
   icon: IconName;
   label: string;
+  tooltipText?: string;
+  tooltipDisabled?: boolean;
   onPress: () => void;
   disabled?: boolean;
   isLoading?: boolean;
@@ -51,20 +53,18 @@ export type QuickAction = {
 
 type Props = {
   actions: QuickAction[];
-  tooltipDisabled?: boolean;
-  tooltipText?: string;
 };
 
-export const QuickActions = ({ actions, tooltipDisabled = false, tooltipText }: Props) => {
+export const QuickActions = ({ actions }: Props) => {
   return (
     <View style={styles.container}>
       {actions.map((action, index) => (
         <LakeTooltip
-          content={tooltipText}
+          content={action.tooltipText}
           placement="top"
           key={index}
-          disabled={tooltipDisabled || isNullishOrEmpty(tooltipText)}
           containerStyle={styles.actionContainer}
+          disabled={action.tooltipDisabled === true || isNullishOrEmpty(action.tooltipText)}
         >
           <Pressable
             key={index}

--- a/packages/lake/src/components/QuickActions.tsx
+++ b/packages/lake/src/components/QuickActions.tsx
@@ -69,7 +69,7 @@ export const QuickActions = ({ actions }: Props) => {
           <Pressable
             key={index}
             onPress={action.onPress}
-            style={action.disabled === true ? styles.disabled : styles.action}
+            style={[styles.action, action.disabled === true && styles.disabled]}
             disabled={action.isLoading === true || action.disabled === true}
           >
             <View

--- a/packages/lake/src/components/QuickActions.tsx
+++ b/packages/lake/src/components/QuickActions.tsx
@@ -43,6 +43,7 @@ export type QuickAction = {
   icon: IconName;
   label: string;
   onPress: () => void;
+  disabled?: boolean;
   isLoading?: boolean;
   backgroundColor?: string;
   color?: string;
@@ -68,8 +69,8 @@ export const QuickActions = ({ actions, tooltipDisabled = false, tooltipText }: 
           <Pressable
             key={index}
             onPress={action.onPress}
-            style={[styles.action, !tooltipDisabled && styles.disabled]}
-            disabled={action.isLoading === true || !tooltipDisabled}
+            style={action.disabled === true ? styles.disabled : styles.action}
+            disabled={action.isLoading === true || action.disabled === true}
           >
             <View
               style={[


### PR DESCRIPTION
Initially the goal of this PR is adding stories for `QuickActions` component.  
But by writing it, I though the API wasn't intuitive because buttons are enabled only when we use `tooltipDisabled` prop.  
And maybe we want to use this component without dealing with tooltip at all, and in this case buttons are disabled by default.  
So I made a change on the API breaking the current usage in partner apps:
- I added `disabled` field in `QuickAction` type to make disabling a button explicit
- I moved `tooltipText` and `tooltipDisabled` in `Action` making possible to have different tooltips for each action button
- disabled state doesn't depends anymore on `tooltipDisabled`  

![image](https://github.com/swan-io/lake/assets/32013054/566453d3-f4cf-4f41-a169-12c3c64b2dbd)

