### PR TITLE
Fix keyboard navigation in Select

### DIFF
--- a/packages/lake/src/components/LakeSelect.tsx
+++ b/packages/lake/src/components/LakeSelect.tsx
@@ -174,7 +174,7 @@ export function LakeSelect<V>({
   const currentlyTypedRef = useRef<string | undefined>(undefined);
   const listItemRefs = useRef<HTMLElement[]>(Array(items.length) as HTMLElement[]);
 
-  const [visible, { close, toggle }] = useDisclosure(false);
+  const [visible, { close, open }] = useDisclosure(false);
 
   const hasValue = isNotNullish(value);
   const isSmall = size === "small";
@@ -182,7 +182,10 @@ export function LakeSelect<V>({
 
   const onKeyDown = useCallback(
     (event: NativeSyntheticEvent<React.KeyboardEvent>) => {
+      // this made a search not visible for user as the native select component
       if (event.nativeEvent.key.length === 1) {
+        event.nativeEvent.stopPropagation();
+
         const currentlyTyped = `${
           currentlyTypedRef.current ?? ""
         }${event.nativeEvent.key.toLowerCase()}`;
@@ -240,7 +243,7 @@ export function LakeSelect<V>({
           (disabled || readOnly) && mode === "borderless" && styles.inputBorderlessDisabled,
           style,
         ]}
-        onPress={toggle}
+        onPress={open}
         onKeyDown={onKeyDown}
         aria-errormessage={error}
       >


### PR DESCRIPTION
I discover an issue with LakeSelect component while using keyboard: when we open the select popover, it's automatically closed.  
I don't know why `onPress` is called twice only with the keyboard (not with mouse navigation). So I just replaced `toogle` by `open`. And it still working as well because the close is handle by popover `onDismiss`.  

I also added `stopPropagation()` in `onKeyDown` to avoid calling other listener while navigating in the Select with keyboard (with storybook it runs shortcuts this is a nightmare)