### PR TITLE
use user language for country select

### DIFF
--- a/packages/shared-business/src/components/CountryPicker.tsx
+++ b/packages/shared-business/src/components/CountryPicker.tsx
@@ -2,6 +2,7 @@ import { Flag } from "@swan-io/lake/src/components/Flag";
 import { LakeSelect } from "@swan-io/lake/src/components/LakeSelect";
 import { useMemo } from "react";
 import { CountryCCA2, CountryCCA3 } from "../constants/countries";
+import { locale } from "../utils/i18n";
 
 export type CountryItem<T extends CountryCCA3> = { cca3: T; cca2?: CountryCCA2; name: string };
 
@@ -31,8 +32,8 @@ export function CountryPicker<T extends CountryCCA3>({
   const countries = useMemo(() => {
     const hasIntl = "Intl" in window && "DisplayNames" in window.Intl;
     const countryResolver =
-      hasIntl && Intl.DisplayNames.supportedLocalesOf(["en"]).length
-        ? new Intl.DisplayNames(["en"], { type: "region" })
+      hasIntl && Intl.DisplayNames.supportedLocalesOf([locale.language]).length
+        ? new Intl.DisplayNames([locale.language], { type: "region" })
         : undefined;
     const seen = new Set();
     return items


### PR DESCRIPTION
We discover that country picker was always in english even when we select a specific language.  
The issue comes from CountryPicker which get country names based on `Intl` API.  
The problem is we hardcoded english as language to use instead of using `locale.language`.  
Maybe with this fix we could remove country translations at least for country items in `countries.ts`