### PR TITLE
Refacto country picker

### DIFF
--- a/packages/shared-business/src/components/BeneficiaryForm.tsx
+++ b/packages/shared-business/src/components/BeneficiaryForm.tsx
@@ -18,8 +18,8 @@ import { match } from "ts-pattern";
 import { v4 as uuid } from "uuid";
 import {
   CountryCCA3,
-  allCountriesItems,
-  individualCountriesItems,
+  allCountries,
+  individualCountries,
   isCountryCCA3,
 } from "../constants/countries";
 import { decodeBirthDate, encodeBirthDate } from "../utils/date";
@@ -539,7 +539,7 @@ export const BeneficiaryForm = forwardRef<BeneficiaryFormRef | undefined, Props>
                               error={error}
                               value={value}
                               placeholder={t("beneficiaryForm.beneficiary.birthCountryPlaceholder")}
-                              items={allCountriesItems}
+                              countries={allCountries}
                               onValueChange={onChange}
                             />
                           )}
@@ -701,7 +701,7 @@ export const BeneficiaryForm = forwardRef<BeneficiaryFormRef | undefined, Props>
                           <CountryPicker
                             id={id}
                             value={value}
-                            items={individualCountriesItems}
+                            countries={individualCountries}
                             onValueChange={onChange}
                           />
                         )}

--- a/packages/shared-business/src/components/CountryPicker.tsx
+++ b/packages/shared-business/src/components/CountryPicker.tsx
@@ -15,11 +15,6 @@ type Props<T extends CountryCCA3> = {
   hideErrors?: boolean;
 };
 
-const removeDuplicated = <T,>(items: T[]): T[] => {
-  const set = new Set(items);
-  return Array.from(set);
-};
-
 export function CountryPicker<T extends CountryCCA3>({
   onValueChange,
   value,
@@ -32,7 +27,8 @@ export function CountryPicker<T extends CountryCCA3>({
   hideErrors,
 }: Props<T>) {
   const items = useMemo(() => {
-    return removeDuplicated(countries)
+    return countries
+      .filter((item, index, array) => array.indexOf(item) === index) // deduplicate
       .map(cca3 => ({
         name: getCountryName(cca3),
         icon: <Flag width={14} icon={cca3} />,


### PR DESCRIPTION
Recently we fixed an issue with translated country name in country picker.  
And something which was disturbing while debugging is we set items with `name` then it was overwritten in `CountryPicker`.  
To avoid this confusion I replaced `items` by `countries: CCA3[]` in `CountryPicker`.  

This PR also replace `getCountryNameByCCA3` by `getCountryName` which is based on `Intl` API.  
At the moment I didn't setup a polyfill as @zoontek suggested because it will make this function async and will have a big impact on all apps by making all CountrySelect items async values.
