### PR TITLE
update address initial values on going to previous step in UBO form

### DIFF
--- a/packages/shared-business/src/components/BeneficiaryForm.tsx
+++ b/packages/shared-business/src/components/BeneficiaryForm.tsx
@@ -288,6 +288,11 @@ export const BeneficiaryForm = forwardRef<BeneficiaryFormRef | undefined, Props>
     const [reference] = useState(() => initialState?.reference ?? uuid());
     const isAddressRequired = accountCountry === "DEU";
     const isBirthInfoRequired = accountCountry !== "DEU";
+    const initialAddress = useRef({
+      residencyAddressLine1: initialState?.residencyAddressLine1,
+      residencyAddressCity: initialState?.residencyAddressCity,
+      residencyAddressPostalCode: initialState?.residencyAddressPostalCode,
+    });
 
     const commonStepValues = useRef<FormValues>();
 
@@ -390,6 +395,18 @@ export const BeneficiaryForm = forwardRef<BeneficiaryFormRef | undefined, Props>
         submitForm(noop);
       }
     }, [initialState, submitForm]);
+
+    useEffect(() => {
+      // store address values on change to set initial values when user use cancel button and go back
+      // without this, address form part initial values stays empty and city and postal code aren't automatically mounted
+      return listenFields(["address", "city", "postalCode"], ({ address, city, postalCode }) => {
+        initialAddress.current = {
+          residencyAddressLine1: address?.value,
+          residencyAddressCity: city?.value,
+          residencyAddressPostalCode: postalCode?.value,
+        };
+      });
+    });
 
     useEffect(() => {
       return listenFields(["type"], () => {
@@ -716,9 +733,11 @@ export const BeneficiaryForm = forwardRef<BeneficiaryFormRef | undefined, Props>
                       <>
                         <AddressFormPart
                           apiKey={googleMapApiKey}
-                          initialAddress={initialState?.residencyAddressLine1 ?? ""}
-                          initialCity={initialState?.residencyAddressCity ?? ""}
-                          initialPostalCode={initialState?.residencyAddressPostalCode ?? ""}
+                          initialAddress={initialAddress.current.residencyAddressLine1 ?? ""}
+                          initialCity={initialAddress.current.residencyAddressCity ?? ""}
+                          initialPostalCode={
+                            initialAddress.current.residencyAddressPostalCode ?? ""
+                          }
                           country={country?.value ?? accountCountry}
                           label={t("beneficiaryForm.beneficiary.address")}
                           Field={Field}


### PR DESCRIPTION
This PR impacts UBO form for german account (with several steps)
There is an issue when:
- you go to address step
- fill an address with city and postal code
- go back
- go next and submit
The city and postal code weren't submitted because there wasn't mounted.  
This PR fixes this by storing edited address as initial values in a ref. So when we go back to address part, city and postal code are automatically mounted.