### PR TITLE
fix sort script for lint-staged

### DIFF
--- a/scripts/locales/sort.ts
+++ b/scripts/locales/sort.ts
@@ -1,27 +1,28 @@
 import fs from "node:fs";
 import os from "node:os";
-import path from "pathe";
 
 const isStringRecord = (value: unknown): value is Record<string, string> =>
   String(value) === "[object Object]" &&
   value != null &&
   Object.values(value).every(item => typeof item === "string");
 
-const localesPath = path.resolve(__dirname, "../src/locales");
-const files = fs.readdirSync(localesPath).map(file => path.join(localesPath, file));
+// Arg automatically provided by lint-staged
+const filePath = process.argv[2];
 
-files.forEach(file => {
-  const content = fs.readFileSync(file, "utf-8");
-  const json: unknown = JSON.parse(content);
+if (filePath == null) {
+  throw new Error("Missing file path");
+}
 
-  if (!isStringRecord(json)) {
-    throw new Error(`Invalid JSON: ${file}`);
-  }
+const content = fs.readFileSync(filePath, "utf-8");
+const json: unknown = JSON.parse(content);
 
-  const sorted = Object.keys(json)
-    .sort()
-    .reduce<Record<string, string>>((acc, key) => ({ ...acc, [key]: json[key] as string }), {});
+if (!isStringRecord(json)) {
+  throw new Error(`Invalid JSON: ${filePath}`);
+}
 
-  fs.writeFileSync(file, JSON.stringify(sorted, null, 2) + os.EOL, "utf-8");
-  console.log(`Sorted ${file}`);
-});
+const sorted = Object.keys(json)
+  .sort()
+  .reduce<Record<string, string>>((acc, key) => ({ ...acc, [key]: json[key] as string }), {});
+
+fs.writeFileSync(filePath, JSON.stringify(sorted, null, 2) + os.EOL, "utf-8");
+console.log(`Sorted ${filePath}`);


### PR DESCRIPTION
While working on translation, I discover the script I made didn't work with lint-staged. So I adapt it to make it work well.
Now instead of trying to sort all files, the script will just sort the file provided as argument by lint-staged.
So now if we edit only some files, the script will sort only modified files instead of all locales files.

