### PR TITLE
fix quick actions layout

### DIFF
--- a/packages/lake/src/components/LakeTooltip.tsx
+++ b/packages/lake/src/components/LakeTooltip.tsx
@@ -10,7 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { StyleSheet, View, ViewStyle } from "react-native";
+import { StyleSheet, View, ViewProps } from "react-native";
 import { usePopper } from "react-popper";
 import { match } from "ts-pattern";
 import { colors, shadows } from "../constants/design";
@@ -108,7 +108,7 @@ type Props = {
   placement: "left" | "top" | "bottom" | "right";
   width?: number;
   togglableOnFocus?: boolean;
-  containerStyle?: ViewStyle;
+  containerStyle?: ViewProps["style"];
   disabled?: boolean;
 };
 

--- a/packages/lake/src/components/QuickActions.tsx
+++ b/packages/lake/src/components/QuickActions.tsx
@@ -12,6 +12,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "flex-start",
     justifyContent: "center",
+    flexWrap: "wrap",
   },
   icon: {
     borderColor: colors.gray[300],
@@ -21,15 +22,16 @@ const styles = StyleSheet.create({
     paddingVertical: spacings[12],
     borderRadius: 32,
   },
+  actionContainer: {
+    flex: 1,
+    minWidth: 100,
+  },
   action: {
     alignItems: "center",
     paddingHorizontal: spacings[12],
-    flexBasis: "30%",
+    paddingVertical: spacings[8],
   },
   disabled: {
-    alignItems: "center",
-    paddingHorizontal: spacings[12],
-    flexBasis: "30%",
     opacity: 0.4,
   },
   label: {
@@ -61,11 +63,12 @@ export const QuickActions = ({ actions, tooltipDisabled = false, tooltipText }: 
           placement="top"
           key={index}
           disabled={tooltipDisabled || isNullishOrEmpty(tooltipText)}
+          containerStyle={styles.actionContainer}
         >
           <Pressable
             key={index}
             onPress={action.onPress}
-            style={tooltipDisabled ? styles.action : styles.disabled}
+            style={[styles.action, !tooltipDisabled && styles.disabled]}
             disabled={action.isLoading === true || !tooltipDisabled}
           >
             <View


### PR DESCRIPTION
The goal of this PR is fixing QuickActions component layout:
- actions width depended on text length, making them not centered
- on small device, button were partially cropped

### Before/after large screen
before:
<img width="499" alt="image" src="https://github.com/swan-io/lake/assets/32013054/c8a24a91-d027-4f37-bd1b-7ab065ef0119">

after:  
<img width="500" alt="image" src="https://github.com/swan-io/lake/assets/32013054/001219a8-2cb8-48d2-81fb-88e93c7e8e53">

### Before/after small screen
before:  
<img width="302" alt="image" src="https://github.com/swan-io/lake/assets/32013054/49e19e66-43b6-48be-afd9-227d584e57e7">

after:  
<img width="300" alt="image" src="https://github.com/swan-io/lake/assets/32013054/99637351-6ad7-4d90-80e3-cd9e2dfa8f87">

