### PR TITLE
UploadArea: forward undefined onRemove

### DIFF
--- a/packages/shared-business/src/components/UploadArea.tsx
+++ b/packages/shared-business/src/components/UploadArea.tsx
@@ -327,14 +327,14 @@ export const UploadArea = ({
                 <FileTile
                   name={document.name ?? t("uploadArea.unknownFileName")}
                   url={document.fileUrl}
-                  onRemove={() => onRemoveFile?.(document.id)}
+                  onRemove={onRemoveFile ? () => onRemoveFile(document.id) : undefined}
                 />
               ))
               .with({ status: "failed" }, ({ error }) => (
                 <FileTile
                   name={document.name ?? t("uploadArea.unknownFileName")}
                   url={document.fileUrl}
-                  onRemove={() => onRemoveFile?.(document.id)}
+                  onRemove={() => (onRemoveFile ? onRemoveFile(document.id) : undefined)}
                   variant="refused"
                   title={error}
                 />


### PR DESCRIPTION
In `FileTile` we hide delete button if `onRemove` is undefined.  
But in `UploadArea`, we always set `onRemove` to anonymous function even if parent prop is undefined. So `onRemove` in `FileTile` is always defined.  

This PR fix this by setting `onRemove = undefined` if `onRemoveFile` is `undefined`