### PR TITLE
add optional label

### DIFF
--- a/packages/shared-business/src/components/BeneficiaryForm.tsx
+++ b/packages/shared-business/src/components/BeneficiaryForm.tsx
@@ -525,6 +525,7 @@ export const BeneficiaryForm = forwardRef<BeneficiaryFormRef | undefined, Props>
                       {({ value, onChange, error }) => (
                         <LakeLabel
                           label={t("beneficiaryForm.beneficiary.birthDate")}
+                          optionalLabel={isBirthInfoRequired ? undefined : t("common.optional")}
                           style={styles.inputContainer}
                           render={id => (
                             <Rifm value={value ?? ""} onChange={onChange} {...rifmDateProps}>
@@ -573,6 +574,9 @@ export const BeneficiaryForm = forwardRef<BeneficiaryFormRef | undefined, Props>
                             {({ value, onChange, error }) => (
                               <LakeLabel
                                 label={t("beneficiaryForm.beneficiary.birthCity")}
+                                optionalLabel={
+                                  isBirthInfoRequired ? undefined : t("common.optional")
+                                }
                                 style={styles.inputContainer}
                                 render={id => (
                                   <GMapCityInput
@@ -604,6 +608,9 @@ export const BeneficiaryForm = forwardRef<BeneficiaryFormRef | undefined, Props>
                             {({ value, onChange, error }) => (
                               <LakeLabel
                                 label={t("beneficiaryForm.beneficiary.birthPostalCode")}
+                                optionalLabel={
+                                  isBirthInfoRequired ? undefined : t("common.optional")
+                                }
                                 style={styles.inputContainer}
                                 render={id => (
                                   <LakeTextInput


### PR DESCRIPTION
In beneficiary form, if account country is german, UBO birth informations are optional.  
This PR adds `optional` label only when it's optional.  

Screenshot with a french account (birth informations are mandatory):  
![image](https://github.com/swan-io/lake/assets/32013054/93527e02-715e-4947-81ca-c76b4aef5458)

Screenshot with a german account (birth informations optional):  
![image](https://github.com/swan-io/lake/assets/32013054/dbfd7b1f-6179-45d7-8ec5-833e0d290b7f)
