### PR TITLE
fix partner image for pdf export

### DIFF
--- a/packages/shared-business/src/components/RIB.tsx
+++ b/packages/shared-business/src/components/RIB.tsx
@@ -1,4 +1,3 @@
-import { AutoWidthImage } from "@swan-io/lake/src/components/AutoWidthImage";
 import { Box } from "@swan-io/lake/src/components/Box";
 import { Fill } from "@swan-io/lake/src/components/Fill";
 import { LakeHeading } from "@swan-io/lake/src/components/LakeHeading";
@@ -15,12 +14,18 @@ import {
   spacings,
 } from "@swan-io/lake/src/constants/design";
 import { isNotNullishOrEmpty } from "@swan-io/lake/src/utils/nullish";
+import { CSSProperties } from "react";
 import { StyleProp, StyleSheet, Text, TextStyle, View } from "react-native";
 import { match } from "ts-pattern";
 import { t } from "../utils/i18n";
 
 const LOGO_MAX_HEIGHT = 26;
 const LOGO_MAX_WIDTH = 200;
+
+const imageStyle: CSSProperties = {
+  objectFit: "contain",
+  objectPosition: "left",
+};
 
 const styles = StyleSheet.create({
   container: {
@@ -118,11 +123,11 @@ const RIBv1 = ({
         <View style={styles.part}>
           <Box direction="row" alignItems="center">
             {isNotNullishOrEmpty(partnerLogoUrl) ? (
-              <AutoWidthImage
-                sourceUri={partnerLogoUrl}
+              <img
+                src={partnerLogoUrl}
+                width={LOGO_MAX_WIDTH}
                 height={LOGO_MAX_HEIGHT}
-                maxWidth={LOGO_MAX_WIDTH}
-                resizeMode="contain"
+                style={imageStyle}
               />
             ) : (
               <SwanLogo style={styles.defaultLogo} />


### PR DESCRIPTION
This PR concerns RIB component for pdf export with playwright.  
When we generate the PDF, the image rendered by `AutoWidthImage` isn't displayed (whereas with a png export the image is well visible).  
If we render just `img` element it works well for PDF export.  
So this PR replace `AutoWidthImage` by `img` with `objectFit: contains` and `objectPosition: left`