### PR TITLE
change default type of beneficiary

### DIFF
--- a/packages/shared-business/src/components/BeneficiaryForm.tsx
+++ b/packages/shared-business/src/components/BeneficiaryForm.tsx
@@ -77,11 +77,11 @@ type Props = {
 };
 
 const beneficiaryTypes: RadioGroupItem<BeneficiaryType>[] = [
+  { value: "HasCapital", name: t("beneficiaryForm.beneficiary.ownershipOfCapital") },
   {
     value: "LegalRepresentative",
     name: t("beneficiaryForm.beneficiary.legalRepresentative"),
   },
-  { value: "HasCapital", name: t("beneficiaryForm.beneficiary.ownershipOfCapital") },
   { value: "Other", name: t("beneficiaryForm.beneficiary.other") },
 ];
 
@@ -332,7 +332,7 @@ export const BeneficiaryForm = forwardRef<BeneficiaryFormRef | undefined, Props>
           sanitize: value => value?.trim(),
         },
         type: {
-          initialValue: initialState?.type ?? "LegalRepresentative",
+          initialValue: initialState?.type ?? "HasCapital",
           validate: validateRequired,
         },
         capitalType: {


### PR DESCRIPTION
Linear ticket: https://linear.app/swan/issue/FRONT-612/onboarding-edit-ubo-modale

This PR changes the default UBO type in beneficiary form.  
As `Ownership of capital` becomes the default value, we put it as first choice.  

![image](https://github.com/swan-io/lake/assets/32013054/d8ac1959-37ca-4028-bfae-619a683f32a5)
