### PR TITLE
Improve auto translate script

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "react-dom": "^18.2.0",
     "semver": "^7.5.2",
     "storybook": "^7.0.22",
-    "tiktoken-node": "^0.0.6",
     "ts-pattern": "^5.0.1",
     "tsx": "^3.12.7",
     "type-fest": "^3.12.0",

--- a/scripts/locales/ai-translate.ts
+++ b/scripts/locales/ai-translate.ts
@@ -238,7 +238,7 @@ const getNewMessages = (
   targetLocaleKeys: Record<string, string>,
 ): Record<string, string> => {
   const alreadyTranslatedKeys = Object.keys(baseLocaleKeys).filter(
-    key => targetLocaleKeys[key] != null,
+    key => targetLocaleKeys[key] != null && targetLocaleKeys[key] !== "",
   );
 
   return omit(baseLocaleKeys, alreadyTranslatedKeys);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8147,11 +8147,6 @@ through@^2.3.8:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-tiktoken-node@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/tiktoken-node/-/tiktoken-node-0.0.6.tgz#7bd6c4b0ad0ce2fbd0f2989ec6b4d4cfd846ab7c"
-  integrity sha512-MiprfzPhoKhCflzl0Jyds0VKibAgUGHfJLvBCAXPpum6Lru6ZoKQGsl8lJP0B94LPpby2B2WveOB2tZVfEZQOQ==
-
 time-zone@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"


### PR DESCRIPTION
This PR removes prompts in `ai-translate` script.  
Initially we add prompts to add some frictions and be sure we don't use this script too much (because we pay OpenAI by request).  
Finally we always use this script with a few keys, so we'll never have big cost. And we can add cost limit in OpenAI dashboard to be sure we don't spend too much money.  

This opens the possibility to use this script in CI jobs.  