### PR TITLE
create workflow to download automatically new translations

### DIFF
--- a/.github/workflows/download-translations.yml
+++ b/.github/workflows/download-translations.yml
@@ -1,0 +1,35 @@
+name: Download translations
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  download-translations:
+    name: Download translations
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # This is required for actions/checkout
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download shared-business translation keys
+        uses: localazy/download@v1
+        with:
+          read_key: ${{ secrets.LOCALAZY_SHARED_BUSINESS_READ_KEY }}
+          write_key: ${{ secrets.LOCALAZY_SHARED_BUSINESS_WRITE_KEY }}
+          groups: shared-business
+
+      - uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.CREATE_PR_TOKEN }}
+          title: Update translations
+          branch: update-translations
+          commit-message: update translations from localazy
+          body: Update translations


### PR DESCRIPTION
This PR adds a new workflow which downloads updated translations from localazy automatically every day.  
This workflow can also be run manually in case we need to download translations before an hot fix during the day.  

To make this working we just need to create an access token with the right to create Pull Request and put it in `CREATE_PR_TOKEN` secret