### PR TITLE
feat: add ability to inject custom components in LakeTextInput

### DIFF
--- a/packages/lake/__stories__/SearchField.stories.tsx
+++ b/packages/lake/__stories__/SearchField.stories.tsx
@@ -4,6 +4,7 @@ import { StyleSheet } from "react-native";
 import { LakeSearchField } from "../src/components/LakeSearchField";
 import { LakeText } from "../src/components/LakeText";
 import { Space } from "../src/components/Space";
+import { Tag } from "../src/components/Tag";
 import { StoryBlock, StoryPart } from "./_StoriesComponents";
 
 const styles = StyleSheet.create({
@@ -37,6 +38,15 @@ export const Variations = () => {
 
         <Space height={12} />
         <LakeText>Debounced value: {text2}</LakeText>
+      </StoryPart>
+
+      <StoryPart title="With counter">
+        <LakeSearchField
+          initialValue="Initial value"
+          placeholder="Placeholder"
+          onChangeText={setText2}
+          renderEnd={() => <Tag>44</Tag>}
+        />
       </StoryPart>
     </StoryBlock>
   );

--- a/packages/lake/__stories__/TextInput.stories.tsx
+++ b/packages/lake/__stories__/TextInput.stories.tsx
@@ -94,9 +94,9 @@ export const Variations = () => {
         <EditableInputText unit="$" />
       </StoryPart>
 
-      <StoryPart title="With custom injected component">
+      <StoryPart title="With end icon and custom injected component">
         <EditableInputText
-          error="teest"
+          error="Hey"
           renderEnd={() => (
             <>
               <LakeCopyButton copyText="Copy" copiedText="Copied" valueToCopy="Copy me" />

--- a/packages/lake/__stories__/TextInput.stories.tsx
+++ b/packages/lake/__stories__/TextInput.stories.tsx
@@ -2,7 +2,9 @@ import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { StyleSheet, View } from "react-native";
 import { Except } from "type-fest";
+import { LakeCopyButton } from "../src/components/LakeCopyButton";
 import { LakeTextInput, LakeTextInputProps } from "../src/components/LakeTextInput";
+import { Tag } from "../src/components/Tag";
 import { StoryBlock, StoryPart } from "./_StoriesComponents";
 
 const styles = StyleSheet.create({
@@ -90,6 +92,18 @@ export const Variations = () => {
 
       <StoryPart title="With unit">
         <EditableInputText unit="$" />
+      </StoryPart>
+
+      <StoryPart title="With custom injected component">
+        <EditableInputText
+          error="teest"
+          renderEnd={() => (
+            <>
+              <LakeCopyButton copyText="Copy" copiedText="Copied" valueToCopy="Copy me" />
+              <Tag>Example tag</Tag>
+            </>
+          )}
+        />
       </StoryPart>
     </StoryBlock>
   );

--- a/packages/lake/src/components/LakeTextInput.tsx
+++ b/packages/lake/src/components/LakeTextInput.tsx
@@ -77,13 +77,13 @@ const styles = StyleSheet.create({
   },
   disabled: {
     backgroundColor: colors.gray[50],
-    // borderColor: colors.gray[50],
+    borderColor: colors.gray[50],
     color: colors.gray[900],
     cursor: "not-allowed",
   },
   readOnly: {
     backgroundColor: colors.gray[50],
-    // borderColor: colors.gray[50],
+    borderColor: colors.gray[50],
     color: colors.gray[900],
   },
   error: {
@@ -178,7 +178,6 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
       valid = false,
       readOnly = false,
       icon,
-      count,
       children,
       unit,
       color = "gray",
@@ -242,18 +241,14 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
               style={[
                 styles.contents,
                 isHovered && isInteractive && styles.hovered,
-                isFocused && styles.focused,
                 isFocused && { borderColor: colors[color][500] },
-
                 readOnly && hasError && styles.readOnlyError,
                 disabled && styles.disabled,
                 readOnly && styles.readOnly,
-
+                isFocused && styles.focused,
                 isNotNullish(unit) && styles.inputWithUnit,
-
                 hasError && styles.error,
                 valid && styles.valid,
-
                 stylesFromProps,
               ]}
             >

--- a/packages/lake/src/components/LakeTextInput.tsx
+++ b/packages/lake/src/components/LakeTextInput.tsx
@@ -37,7 +37,6 @@ const styles = StyleSheet.create({
   },
   container: {
     flexGrow: 1,
-    flexShrink: 1,
     flexDirection: "row",
     alignItems: "stretch",
   },
@@ -45,21 +44,25 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     flexShrink: 1,
     flexDirection: "row",
-    alignItems: "stretch",
+    width: "100%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: radii[6],
+    backgroundColor: backgroundColor.accented,
+    borderColor: colors.gray[100],
+    borderWidth: 1,
+    paddingHorizontal: spacings[8],
   },
   input: {
     ...texts.regular,
-    paddingHorizontal: spacings[16],
+    flexGrow: 1,
     outlineStyle: "none",
-    height: 40,
-    borderColor: colors.gray[100],
     placeholderTextColor: colors.gray[400],
-    borderWidth: 1,
-    borderRadius: radii[6],
-    backgroundColor: backgroundColor.accented,
     color: colors.gray[900],
-    width: "100%",
-    flexShrink: 1,
+    paddingHorizontal: spacings[8],
+    height: 40,
+    minWidth: 0,
   },
   multilineInput: {
     height: "auto",
@@ -74,46 +77,42 @@ const styles = StyleSheet.create({
   },
   disabled: {
     backgroundColor: colors.gray[50],
-    borderColor: colors.gray[50],
+    // borderColor: colors.gray[50],
     color: colors.gray[900],
     cursor: "not-allowed",
   },
   readOnly: {
     backgroundColor: colors.gray[50],
-    borderColor: colors.gray[50],
+    // borderColor: colors.gray[50],
     color: colors.gray[900],
-  },
-  withIcon: {
-    paddingLeft: spacings[48],
   },
   error: {
     borderColor: colors.negative[400],
-    paddingRight: spacings[48],
   },
   valid: {
     borderColor: colors.positive[500],
-    paddingRight: spacings[48],
   },
   readOnlyError: {
     borderColor: TRANSPARENT,
     paddingRight: spacings[32],
   },
   endIcon: {
-    position: "absolute",
-    right: spacings[16],
-    top: "50%",
-    transform: "translateY(-50%)",
+    marginHorizontal: spacings[8],
+  },
+  endComponents: {
+    flexDirection: "row",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    marginLeft: spacings[8],
   },
   icon: {
-    position: "absolute",
-    left: spacings[16],
-    top: "50%",
-    transform: "translateY(-50%)",
+    marginLeft: spacings[8],
+    margiRight: spacings[4],
   },
   readOnlyEndIcon: {
     right: 0,
   },
-
   unit: {
     backgroundColor: colors.gray[50],
     paddingHorizontal: spacings[16],
@@ -165,6 +164,7 @@ export type LakeTextInputProps = Except<
   onChange?: ChangeEventHandler<HTMLInputElement>;
   maxCharCount?: number;
   help?: string;
+  renderEnd?: () => ReactNode;
 };
 
 export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
@@ -178,6 +178,7 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
       valid = false,
       readOnly = false,
       icon,
+      count,
       children,
       unit,
       color = "gray",
@@ -191,10 +192,12 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
       value,
       defaultValue,
       multiline = false,
-      //maxCharCount is different from maxLength(props inherited of TextInput), maxLength truncates the text in the limitation asked,
+      //maxCharCount is different from maxLength(props inherited of TextInput)
+      //maxLength truncates the text in the limitation asked,
       //maxCharCount doesn't have limitation but displays a counter of characters
       maxCharCount,
       help,
+      renderEnd,
       ...props
     }: LakeTextInputProps,
     forwardRef,
@@ -235,7 +238,29 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
       <View style={commonStyles.fill}>
         <View style={styles.root} aria-errormessage={error}>
           <View style={styles.container}>
-            <View style={styles.contents}>
+            <View
+              style={[
+                styles.contents,
+                isHovered && isInteractive && styles.hovered,
+                isFocused && styles.focused,
+                isFocused && { borderColor: colors[color][500] },
+
+                readOnly && hasError && styles.readOnlyError,
+                disabled && styles.disabled,
+                readOnly && styles.readOnly,
+
+                isNotNullish(unit) && styles.inputWithUnit,
+
+                hasError && styles.error,
+                valid && styles.valid,
+
+                stylesFromProps,
+              ]}
+            >
+              {isNotNullish(icon) && (
+                <Icon name={icon} size={20} color={colors.current.primary} style={styles.icon} />
+              )}
+
               <TextInput
                 aria-expanded={ariaExpanded}
                 aria-controls={ariaControls}
@@ -252,19 +277,13 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
                 style={[
                   styles.input,
                   multiline && styles.multilineInput,
-                  hasError && styles.error,
-                  valid && styles.valid,
-                  isNotNullish(icon) && styles.withIcon,
                   readOnly && hasError && styles.readOnlyError,
                   disabled && styles.disabled,
                   readOnly && styles.readOnly,
-                  isHovered && isInteractive && styles.hovered,
-                  isNotNullish(unit) && styles.inputWithUnit,
-                  isFocused && styles.focused,
-                  isFocused && { borderColor: colors[color][500] },
-                  stylesFromProps,
                 ]}
               />
+
+              {isNotNullish(renderEnd) && <View style={styles.endComponents}>{renderEnd()}</View>}
 
               {validating && (
                 <ActivityIndicator
@@ -290,10 +309,6 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
                   color={colors.positive[400]}
                   style={[styles.endIcon, readOnly && styles.readOnlyEndIcon]}
                 />
-              )}
-
-              {isNotNullish(icon) && (
-                <Icon name={icon} size={20} color={colors.current.primary} style={styles.icon} />
               )}
             </View>
 


### PR DESCRIPTION
We need to add a counter at the end of the search bar :

<img width="427" alt="image" src="https://github.com/swan-io/lake/assets/26482371/8b373651-fe81-442c-bdf0-a6befec873bf">


So we've added a new `renderEnd` prop to `LakeTextInput` :

<img width="445" alt="image" src="https://github.com/swan-io/lake/assets/26482371/99778de3-a06f-4982-bf1d-d193dfd0a39d">
