### PR TITLE
fix: input are 42px height instead of 40

### DIFF
--- a/packages/lake/src/components/LakeTextInput.tsx
+++ b/packages/lake/src/components/LakeTextInput.tsx
@@ -61,7 +61,7 @@ const styles = StyleSheet.create({
     placeholderTextColor: colors.gray[400],
     color: colors.gray[900],
     paddingHorizontal: spacings[8],
-    height: 40,
+    height: 38,
     minWidth: 0,
   },
   multilineInput: {


### PR DESCRIPTION
[a recent commit](https://github.com/swan-io/lake/pull/115) has introduced a regression that increase of 2px the input height
the border is now applied on the container and we need to compensate it in the height