### PR TITLE
fix: popover aligment issue on combobox with icon

### DIFF
--- a/packages/lake/src/components/LakeCombobox.tsx
+++ b/packages/lake/src/components/LakeCombobox.tsx
@@ -117,6 +117,7 @@ const getItemLayout: <I>(
 
 export type LakeComboboxProps<I> = {
   inputRef?: RefObject<unknown>;
+  inputContainerRef?: RefObject<unknown>;
   value: string;
   items: AsyncData<Result<I[], unknown>>;
   itemHeight?: number;
@@ -165,7 +166,11 @@ const LakeComboboxWithRef = <I,>(
 ) => {
   const ref = useRef<TextInput>(null);
 
-  const inputTextRef = useMergeRefs(ref, inputRef as RefObject<unknown>);
+  const inputTextRef = useMergeRefs(
+    ref,
+    inputRef as RefObject<unknown>,
+  );
+
   const listRef = useRef<FlatList>(null);
   const listContainerRef = useRef<View>(null);
   const blurTimeoutId = useRef<number | undefined>(undefined);
@@ -237,7 +242,7 @@ const LakeComboboxWithRef = <I,>(
   return (
     <View>
       <LakeTextInput
-        ref={inputTextRef as Ref<TextInput>}
+        containerRef={inputTextRef as Ref<View>}
         style={styles.input}
         ariaExpanded={isFocused}
         ariaControls={isFocused ? suggestionsId : ""}

--- a/packages/lake/src/components/LakeCombobox.tsx
+++ b/packages/lake/src/components/LakeCombobox.tsx
@@ -163,7 +163,6 @@ const LakeComboboxWithRef = <I,>(
   }: LakeComboboxProps<I>,
   externalRef: ForwardedRef<LakeComboboxRef>,
 ) => {
-  const containerRef = useRef<View>(null);
   const ref = useRef<TextInput>(null);
 
   const inputTextRef = useMergeRefs(ref, inputRef as RefObject<unknown>);
@@ -237,7 +236,7 @@ const LakeComboboxWithRef = <I,>(
   }, [close]);
 
   return (
-    <View ref={containerRef}>
+    <View>
       <LakeTextInput
         containerRef={inputTextRef as Ref<View>}
         style={styles.input}
@@ -265,7 +264,7 @@ const LakeComboboxWithRef = <I,>(
         role="listbox"
         matchReferenceWidth={true}
         onDismiss={close}
-        referenceRef={containerRef}
+        referenceRef={ref}
         autoFocus={false}
         returnFocus={true}
         visible={isFocused && !items.isNotAsked()}

--- a/packages/lake/src/components/LakeCombobox.tsx
+++ b/packages/lake/src/components/LakeCombobox.tsx
@@ -117,7 +117,6 @@ const getItemLayout: <I>(
 
 export type LakeComboboxProps<I> = {
   inputRef?: RefObject<unknown>;
-  inputContainerRef?: RefObject<unknown>;
   value: string;
   items: AsyncData<Result<I[], unknown>>;
   itemHeight?: number;

--- a/packages/lake/src/components/LakeCombobox.tsx
+++ b/packages/lake/src/components/LakeCombobox.tsx
@@ -166,10 +166,7 @@ const LakeComboboxWithRef = <I,>(
 ) => {
   const ref = useRef<TextInput>(null);
 
-  const inputTextRef = useMergeRefs(
-    ref,
-    inputRef as RefObject<unknown>,
-  );
+  const inputTextRef = useMergeRefs(ref, inputRef as RefObject<unknown>);
 
   const listRef = useRef<FlatList>(null);
   const listContainerRef = useRef<View>(null);

--- a/packages/lake/src/components/LakeTextInput.tsx
+++ b/packages/lake/src/components/LakeTextInput.tsx
@@ -251,6 +251,7 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
                 valid && styles.valid,
                 stylesFromProps,
               ]}
+              ref={mergedRef}
             >
               {isNotNullish(icon) && (
                 <Icon name={icon} size={20} color={colors.current.primary} style={styles.icon} />
@@ -260,7 +261,6 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
                 aria-expanded={ariaExpanded}
                 aria-controls={ariaControls}
                 inputMode={inputMode}
-                ref={mergedRef}
                 {...props}
                 defaultValue={defaultValue}
                 value={isNullish(defaultValue) ? value ?? "" : value}

--- a/packages/lake/src/components/LakeTextInput.tsx
+++ b/packages/lake/src/components/LakeTextInput.tsx
@@ -1,4 +1,12 @@
-import { ChangeEventHandler, forwardRef, ReactNode, Ref, useCallback, useRef, useState } from "react";
+import {
+  ChangeEventHandler,
+  forwardRef,
+  ReactNode,
+  Ref,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import {
   ActivityIndicator,
   NativeSyntheticEvent,
@@ -165,7 +173,7 @@ export type LakeTextInputProps = Except<
   maxCharCount?: number;
   help?: string;
   renderEnd?: () => ReactNode;
-  containerRef?: Ref<View>,
+  containerRef?: Ref<View>;
 };
 
 export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(

--- a/packages/lake/src/components/LakeTextInput.tsx
+++ b/packages/lake/src/components/LakeTextInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, forwardRef, ReactNode, useCallback, useRef, useState } from "react";
+import { ChangeEventHandler, forwardRef, ReactNode, Ref, useCallback, useRef, useState } from "react";
 import {
   ActivityIndicator,
   NativeSyntheticEvent,
@@ -165,6 +165,7 @@ export type LakeTextInputProps = Except<
   maxCharCount?: number;
   help?: string;
   renderEnd?: () => ReactNode;
+  containerRef?: Ref<View>,
 };
 
 export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
@@ -191,6 +192,7 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
       value,
       defaultValue,
       multiline = false,
+      containerRef,
       //maxCharCount is different from maxLength(props inherited of TextInput)
       //maxLength truncates the text in the limitation asked,
       //maxCharCount doesn't have limitation but displays a counter of characters
@@ -251,7 +253,7 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
                 valid && styles.valid,
                 stylesFromProps,
               ]}
-              ref={mergedRef}
+              ref={containerRef}
             >
               {isNotNullish(icon) && (
                 <Icon name={icon} size={20} color={colors.current.primary} style={styles.icon} />
@@ -269,6 +271,7 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
                 readOnly={!isInteractive}
                 onChange={onChange as TextInputProps["onChange"]}
                 multiline={multiline}
+                ref={mergedRef}
                 style={[
                   styles.input,
                   multiline && styles.multilineInput,


### PR DESCRIPTION
Cause by https://github.com/swan-io/lake/pull/115

Before :

<img width="557" alt="image" src="https://github.com/swan-io/lake/assets/26482371/ecdd5262-311f-4280-8c37-f3706b25429e">



After :

<img width="624" alt="image" src="https://github.com/swan-io/lake/assets/26482371/ab4a8f39-5098-4ee4-a687-4a5108b37772">
