### PR TITLE
fix: prevent combobox from opening on focus

### DIFF
--- a/packages/lake/src/components/LakeCombobox.tsx
+++ b/packages/lake/src/components/LakeCombobox.tsx
@@ -170,8 +170,9 @@ const LakeComboboxWithRef = <I,>(
   const listRef = useRef<FlatList>(null);
   const listContainerRef = useRef<View>(null);
   const blurTimeoutId = useRef<number | undefined>(undefined);
-  const [isFocused, { open, close }] = useDisclosure(false);
+  const [isFocused, { open, close }] = useDisclosure(false, () => setHasChanged(false));
   const [isFetchingAdditionalInfo, setIsFetchingAdditionalInfo] = useState(false);
+  const [hasChanged, setHasChanged] = useState(false);
 
   useImperativeHandle(externalRef, () => {
     return {
@@ -251,7 +252,10 @@ const LakeComboboxWithRef = <I,>(
         error={error}
         hideErrors={hideErrors}
         onChangeText={onValueChange}
-        onChange={onChange}
+        onChange={event => {
+          setHasChanged(true);
+          onChange?.(event);
+        }}
         onFocus={handleFocus}
         onBlur={handleBlur}
         onKeyPress={handleKeyPress}
@@ -267,7 +271,7 @@ const LakeComboboxWithRef = <I,>(
         referenceRef={containerRef}
         autoFocus={false}
         returnFocus={true}
-        visible={isFocused && !items.isNotAsked()}
+        visible={isFocused && !items.isNotAsked() && hasChanged}
         underlay={false}
         forcedMode="Dropdown"
       >

--- a/packages/lake/src/hooks/useDisclosure.ts
+++ b/packages/lake/src/hooks/useDisclosure.ts
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 
 export const useDisclosure = (
   initialValue: boolean,
+  onClose?: () => void,
 ): [
   visible: boolean,
   fns: {
@@ -17,7 +18,10 @@ export const useDisclosure = (
     useMemo(
       () => ({
         open: () => setValue(true),
-        close: () => setValue(false),
+        close: () => {
+          setValue(false);
+          onClose?.();
+        },
         toggle: () => setValue(prevValue => !prevValue),
       }),
       [],


### PR DESCRIPTION
when the user click outside of the combobox, due to the focustrap, it get back the focus and it opens again
this pr forbids the combobox to open unless the user starts to type inside