### PR TITLE
feat: add the posibility to copy a different text in CopyableRegularTextCell

### DIFF
--- a/packages/lake/src/components/FixedListViewCells.tsx
+++ b/packages/lake/src/components/FixedListViewCells.tsx
@@ -227,11 +227,13 @@ export const SimpleRegularTextCell = ({
 export const CopyableRegularTextCell = ({
   variant = "regular",
   text,
+  textToCopy,
   copyWording,
   copiedWording,
 }: {
   variant?: TextVariant;
   text: string;
+  textToCopy?: string;
   copyWording: string;
   copiedWording: string;
 }) => {
@@ -240,7 +242,7 @@ export const CopyableRegularTextCell = ({
   const onPress = useCallback(
     (event: GestureResponderEvent) => {
       event.preventDefault();
-      Clipboard.setString(text);
+      Clipboard.setString(textToCopy ?? text);
       setVisibleState("copied");
     },
     [text],


### PR DESCRIPTION
Sometimes, we may need to copy a different text than the one displayed in the cell. 

For example here, we need the complete IBAN, not the truncated one :
<img width="176" alt="image" src="https://github.com/swan-io/lake/assets/26482371/b587ea37-a427-49d4-be39-526786a5a3db">
