### PR TITLE
Fix LakeCombobox

### DIFF
--- a/packages/lake/src/components/AutocompleteSearchInput.tsx
+++ b/packages/lake/src/components/AutocompleteSearchInput.tsx
@@ -66,6 +66,7 @@ export const AutocompleteSearchInput = <T,>({
         lastRequest.current = undefined; // avoid to cancel twice the same request
 
         onValueChange(value);
+
         if (value.length <= 3 || !shouldDisplaySuggestions) {
           return setState(AsyncData.NotAsked());
         }

--- a/packages/lake/src/components/LakeCombobox.tsx
+++ b/packages/lake/src/components/LakeCombobox.tsx
@@ -252,7 +252,7 @@ const LakeComboboxWithRef = <I,>(
     window.clearTimeout(blurTimeoutId.current);
 
     blurTimeoutId.current = window.setTimeout(() => {
-      setState(prevState => (prevState === "opened" ? "closed" : prevState));
+      setState("dismissed");
     }, 100);
   }, []);
 
@@ -284,7 +284,7 @@ const LakeComboboxWithRef = <I,>(
         id={suggestionsId}
         role="listbox"
         matchReferenceWidth={true}
-        onDismiss={dismiss}
+        onEscapeKey={dismiss}
         referenceRef={ref}
         autoFocus={false}
         returnFocus={true}

--- a/packages/lake/src/components/LakeCombobox.tsx
+++ b/packages/lake/src/components/LakeCombobox.tsx
@@ -33,6 +33,7 @@ import { Icon, IconName } from "./Icon";
 import { LakeTextInput, LakeTextInputProps } from "./LakeTextInput";
 import { LoadingView } from "./LoadingView";
 import { Popover } from "./Popover";
+import { Separator } from "./Separator";
 import { Space } from "./Space";
 
 const DEFAULT_ELEMENT_HEIGHT = 64;
@@ -52,9 +53,6 @@ const styles = StyleSheet.create({
     transitionProperty: "background-color",
     transitionDuration: "200ms",
     outlineStyle: "none",
-    borderColor: colors.gray[100],
-    borderStyle: "solid",
-    borderBottomWidth: 1,
     justifyContents: "center",
   },
   hoveredItem: {
@@ -324,6 +322,7 @@ const LakeComboboxWithRef = <I,>(
                         role="list"
                         data={items}
                         style={styles.flatList}
+                        ItemSeparatorComponent={Separator}
                         renderItem={({ item }) => {
                           const rendered = renderItem(item);
 

--- a/packages/lake/src/components/LakeCombobox.tsx
+++ b/packages/lake/src/components/LakeCombobox.tsx
@@ -235,12 +235,7 @@ const LakeComboboxWithRef = <I,>(
   const handleChangeText = useCallback(
     (value: string) => {
       onValueChange(value);
-
-      if (isNotEmpty(value)) {
-        setState("opened");
-      } else {
-        setState("closed");
-      }
+      setState(isNotEmpty(value) ? "opened" : "closed");
     },
     [onValueChange],
   );

--- a/packages/lake/src/components/Popover.tsx
+++ b/packages/lake/src/components/Popover.tsx
@@ -10,6 +10,7 @@ import {
 import { match, P } from "ts-pattern";
 import { Animation, animations, backgroundColor, radii, shadows } from "../constants/design";
 import { useResponsive } from "../hooks/useResponsive";
+import { noop } from "../utils/function";
 import { BottomPanel } from "./BottomPanel";
 import { FocusTrap } from "./FocusTrap";
 import { Portal } from "./Portal";
@@ -23,7 +24,8 @@ type Props = {
   describedBy?: string;
   matchReferenceWidth?: boolean;
   matchReferenceMinWidth?: boolean;
-  onDismiss: () => void;
+  onDismiss?: () => void;
+  onEscapeKey?: () => void;
   referenceRef: RefObject<unknown>;
   returnFocus?: boolean;
   autoFocus?: boolean;
@@ -117,7 +119,8 @@ export const Popover = memo<Props>(
     describedBy,
     matchReferenceWidth = false,
     matchReferenceMinWidth = false,
-    onDismiss,
+    onDismiss = noop,
+    onEscapeKey = onDismiss,
     referenceRef,
     returnFocus = true,
     autoFocus = true,
@@ -275,7 +278,7 @@ export const Popover = memo<Props>(
                     focusLock={true}
                     returnFocus={returnFocus}
                     autoFocus={autoFocus}
-                    onEscapeKey={onDismiss}
+                    onEscapeKey={onEscapeKey}
                     onClickOutside={underlay ? undefined : onClickOutside}
                   >
                     <Pressable tabIndex={-1} onPress={onPress} style={styles.defaultCursor}>


### PR DESCRIPTION
My last PR introduces a regression, this one fixes it. To simplify the logic, I introduced two distinct closed states: `closed` and `dismissed`

- When the combobox is `closed`, it will open on input focus or text change
- When the combobox `dismissed`, it will NOT open on input focus, but will on text change