### PR TITLE
fix: allow ellipsis when laketext has a tooltip

### DIFF
--- a/packages/lake/src/components/LakeText.tsx
+++ b/packages/lake/src/components/LakeText.tsx
@@ -32,6 +32,16 @@ type Props = TextProps & {
   tooltip?: Omit<ComponentProps<typeof LakeTooltip>, "children">;
 };
 
+const styles = StyleSheet.create({
+  tooltip: {
+    width: "100%",
+  },
+  ellipsis: {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  },
+});
+
 export const LakeText = forwardRef<Text, Props>(
   (
     {
@@ -58,8 +68,8 @@ export const LakeText = forwardRef<Text, Props>(
       {...props}
     >
       {tooltip ? (
-        <LakeTooltip {...tooltip}>
-          <Text>{children}</Text>
+        <LakeTooltip containerStyle={styles.tooltip} {...tooltip}>
+          <Text style={styles.ellipsis}>{children}</Text>
         </LakeTooltip>
       ) : (
         children


### PR DESCRIPTION
<img width="344" alt="image" src="https://github.com/swan-io/lake/assets/26482371/c460c847-f0ab-4aa6-bbd2-38928b6f663b">
