### PR TITLE
fix: disabled link does not work properly

### DIFF
--- a/packages/lake/src/components/Link.tsx
+++ b/packages/lake/src/components/Link.tsx
@@ -49,10 +49,11 @@ export const Link = memo(
         <PressableText
           {...props}
           role={role}
+          disabled={disabled}
           aria-disabled={disabled}
           tabIndex={isNotNullish(tabIndex) ? tabIndex : disabled ? -1 : 0}
           aria-current={active ? ariaCurrentValue : undefined}
-          href={to}
+          href={!disabled ? to : undefined}
           onPress={(event: unknown) => {
             const e = event as React.MouseEvent<HTMLAnchorElement>;
             if (disabled) {

--- a/packages/lake/src/components/Pressable.tsx
+++ b/packages/lake/src/components/Pressable.tsx
@@ -35,7 +35,7 @@ const styles = StyleSheet.create({
     touchAction: "manipulation",
   },
   disabled: {
-    pointerEvents: "none",
+    cursor: "not-allowed",
   },
 });
 


### PR DESCRIPTION
- When disabled, the link doesn't get the aria-disabled property and still can be visited using the kb
- To be consistent with the buttons and to allow to change the cursor, `cursor-event` was also dropped and the href prop is set to undefined when disabled