### PR TITLE
Card3dPreview: fix texture loading

### DIFF
--- a/packages/lake/src/components/Card3dPreview.tsx
+++ b/packages/lake/src/components/Card3dPreview.tsx
@@ -257,6 +257,10 @@ export const Card = forwardRef<THREE.Group, CardProps>(
           materials.card.map = blackTexture;
         })
         .exhaustive();
+
+      // force threejs to update material
+      // because sometimes it doesn't apply texture on load randomly
+      materials.card.needsUpdate = true;
     }, [color, materials.card, silverTexture, blackTexture]);
 
     // this avoid to have onSvgError as dependency of the effect below which should run only on logo change


### PR DESCRIPTION
Hello @bloodyowl @zoontek @sandrine-ds and @ncomont 

I hope everyone is fine and had a great week-end.  

I create this PR because while working on the new design studio, I've got an issue with ThreeJS: sometimes and randomly, the card color wasn't displayed (it stays white instead of silver or black).  
This PR fix this issue by forcing threeJS to update the card material after applying the texture.  

Can you merge it and create a new lake release with this fix as soon as you can please 🙏