### PR TITLE
fix: Slider component

### DIFF
--- a/packages/lake/src/components/Slider.tsx
+++ b/packages/lake/src/components/Slider.tsx
@@ -10,6 +10,7 @@ const BUTTON_SIZE = 20;
 const styles = StyleSheet.create({
   container: {
     height: BUTTON_SIZE,
+    width: "100%",
   },
   disabled: {
     cursor: "not-allowed",


### PR DESCRIPTION
Hello @bloodyowl 

By upgrading lake to version `v2.7.32` I discover an issue with `Slider` component. I explain it with screenshot in this issue: https://github.com/swan-io/lake/issues/160

Finally I found an easy fix by forcing the with to `100%`. In my case it fixes my issue. And I'm confident this will not add breaking change to your apps.  

I also thought about using `LakeSlider` but it automatically becomes a text input because of the with of my form.  
But if you prefer I can make another PR which adapts `LakeSlider` for my needs.