### PR TITLE
Add rejection helpers

### DIFF
--- a/packages/lake/src/utils/urql.ts
+++ b/packages/lake/src/utils/urql.ts
@@ -1,0 +1,61 @@
+import { Result } from "@swan-io/boxed";
+import { Except, SetRequired } from "type-fest";
+import {
+  AnyVariables,
+  CombinedError,
+  OperationResult,
+  UseQueryArgs,
+  UseQueryResponse,
+  UseQueryState,
+  useQuery,
+} from "urql";
+import { isNotNullish, isNullish } from "./nullish";
+
+export const parseOperationResult = <T>({ error, data }: OperationResult<T>): T => {
+  if (isNotNullish(error)) {
+    throw error;
+  }
+
+  if (isNullish(data)) {
+    throw new CombinedError({
+      networkError: new Error("No Content"),
+    });
+  }
+
+  return data;
+};
+
+export const useQueryWithErrorBoundary = <
+  Data = unknown,
+  Variables extends AnyVariables = AnyVariables,
+>(
+  options: UseQueryArgs<Variables, Data>,
+): [
+  SetRequired<Except<UseQueryState<Data, Variables>, "fetching" | "error">, "data">,
+  UseQueryResponse[1],
+] => {
+  const [{ fetching, data, error, ...rest }, reexecuteQuery] = useQuery<Data, Variables>(options);
+
+  if (isNotNullish(error)) {
+    throw error;
+  }
+
+  if (isNullish(data)) {
+    throw new CombinedError({
+      networkError: new Error("No Content"),
+    });
+  }
+
+  return [{ data, ...rest }, reexecuteQuery];
+};
+
+export const filterRejectionsToPromise = <T extends { __typename: string }>(input: T) =>
+  (input.__typename.endsWith("Rejection")
+    ? Promise.reject(new Error(input.__typename))
+    : Promise.resolve(input)) as Promise<Exclude<T, { __typename: `${string}Rejection` }>>;
+
+export const filterRejectionsToResult = <T extends { __typename: string }>(input: T) =>
+  (input.__typename.endsWith("Rejection") ? Result.Error(input) : Result.Ok(input)) as Result<
+    Exclude<T, { __typename: `${string}Rejection` }>,
+    Extract<T, { __typename: `${string}Rejection` }>
+  >;

--- a/packages/shared-business/package.json
+++ b/packages/shared-business/package.json
@@ -41,6 +41,7 @@
     "react-ux-form": "^1.5.0",
     "rifm": "^0.12.1",
     "ts-pattern": "^5.0.5",
+    "urql": "^4.0.5",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/packages/shared-business/src/locales/de.json
+++ b/packages/shared-business/src/locales/de.json
@@ -103,6 +103,7 @@
   "datePicker.month.november": "November",
   "datePicker.month.october": "Oktober",
   "datePicker.month.september": "September",
+  "error.generic": "Es ist ein Fehler aufgetreten",
   "error.network.500": "Interner Serverfehler",
   "error.network.503": "Dienst nicht verfügbar",
   "error.requiredField": "Das ist ein Pflichtfeld",

--- a/packages/shared-business/src/locales/en.json
+++ b/packages/shared-business/src/locales/en.json
@@ -103,6 +103,7 @@
   "datePicker.month.november": "November",
   "datePicker.month.october": "October",
   "datePicker.month.september": "September",
+  "error.generic": "An error occurred",
   "error.network.500": "Internal server error",
   "error.network.503": "Service unavailable",
   "error.requiredField": "This field is required",

--- a/packages/shared-business/src/locales/es.json
+++ b/packages/shared-business/src/locales/es.json
@@ -100,6 +100,7 @@
   "datePicker.month.june": "Junio",
   "datePicker.month.march": "Marzo",
   "datePicker.month.may": "Mayo",
+  "error.generic": "Ha ocurrido un error",
   "datePicker.month.november": "Noviembre",
   "datePicker.month.october": "Octubre",
   "datePicker.month.september": "Septiembre",

--- a/packages/shared-business/src/locales/fr.json
+++ b/packages/shared-business/src/locales/fr.json
@@ -1,5 +1,6 @@
 {
   "addressFormPart.addressLabel": "Saisissez votre adresse",
+  "error.generic": "Une erreur est survenue",
   "addressFormPart.cityLabel": "Ville",
   "addressFormPart.placeholder": "Commencer à écrire...",
   "addressFormPart.postCodeLabel": "Code postal",

--- a/packages/shared-business/src/locales/it.json
+++ b/packages/shared-business/src/locales/it.json
@@ -1,4 +1,5 @@
 {
+  "error.generic": "Si è verificato un errore",
   "addressFormPart.addressLabel": "Digita il tuo indirizzo",
   "addressFormPart.cityLabel": "Città",
   "addressFormPart.placeholder": "Inizia a digitare...",

--- a/packages/shared-business/src/locales/nl.json
+++ b/packages/shared-business/src/locales/nl.json
@@ -1,4 +1,5 @@
 {
+  "error.generic": "Er is een fout opgetreden",
   "addressFormPart.addressLabel": "Typ uw adres",
   "addressFormPart.cityLabel": "Stad",
   "addressFormPart.placeholder": "Begin met typen...",

--- a/packages/shared-business/src/locales/pt.json
+++ b/packages/shared-business/src/locales/pt.json
@@ -1,4 +1,5 @@
 {
+  "error.generic": "Ocorreu um erro",
   "addressFormPart.addressLabel": "Introduza o seu endereço",
   "addressFormPart.cityLabel": "Cidade",
   "addressFormPart.placeholder": "Comece a escrever...",

--- a/packages/shared-business/src/utils/i18n.ts
+++ b/packages/shared-business/src/utils/i18n.ts
@@ -14,6 +14,7 @@ import localizedFormat from "dayjs/plugin/localizedFormat";
 import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
 import { ReactElement, ReactNode, cloneElement, isValidElement } from "react";
+import { P, match } from "ts-pattern";
 import translationDE from "../locales/de.json";
 import translationEN from "../locales/en.json";
 import translationES from "../locales/es.json";
@@ -149,3 +150,18 @@ export const rifmDateProps: RifmProps = getRifmProps({
   charMap: { 2: "/", 4: "/" },
   maxLength: 8,
 });
+
+const translationKeys = Object.keys(translationEN);
+const isTranslationKey = (key: string): key is TranslationKey => translationKeys.includes(key);
+
+export const translateError = (error: unknown) => {
+  const key = match(error)
+    .returnType<string>()
+    .with({ __typename: P.select(P.string) }, __typename => `rejection.${__typename}`)
+    .with(P.string, __typename => `rejection.${__typename}`)
+    .with({ response: { status: P.select(P.number) } }, status => `error.network.${status}`)
+    .with(P.instanceOf(Error), ({ message }) => `rejection.${message}`)
+    .otherwise(() => "error.generic");
+
+  return t(isTranslationKey(key) ? key : "error.generic");
+};

--- a/packages/shared-business/src/utils/i18n.ts
+++ b/packages/shared-business/src/utils/i18n.ts
@@ -15,6 +15,7 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
 import { ReactElement, ReactNode, cloneElement, isValidElement } from "react";
 import { P, match } from "ts-pattern";
+import { CombinedError } from "urql";
 import translationDE from "../locales/de.json";
 import translationEN from "../locales/en.json";
 import translationES from "../locales/es.json";
@@ -159,7 +160,11 @@ export const translateError = (error: unknown) => {
     .returnType<string>()
     .with({ __typename: P.select(P.string) }, __typename => `rejection.${__typename}`)
     .with(P.string, __typename => `rejection.${__typename}`)
-    .with({ response: { status: P.select(P.number) } }, status => `error.network.${status}`)
+    .with(P.instanceOf(CombinedError), ({ response }) =>
+      match(response)
+        .with({ response: { status: P.select(P.number) } }, status => `error.network.${status}`)
+        .otherwise(() => "error.generic"),
+    )
     .with(P.instanceOf(Error), ({ message }) => `rejection.${message}`)
     .otherwise(() => "error.generic");
 


### PR DESCRIPTION
- Move some urql utils in lake (currently duplicated in every codebases)
- Add `translateError` for better rejections errors
- Add `filterRejectionsToPromise` and `filterRejectionsToResult`

Usage:

```ts
requestSupportingDocumentCollectionReview({
  input: { supportingDocumentCollectionId: collection.id },
})
  .then(parseOperationResult)
  .then(data => data.requestSupportingDocumentCollectionReview)
  .then(filterRejectionsToPromise)
  .then(refetchCollection)
  .catch(error => showToast(translateError(error)));
```

```ts
unsuspendPhysicalCard({
  input: { cardId, consentRedirectUrl: url },
})
  .mapOk(data => data.resumePhysicalCard)
  .mapOkToResult(filterRejectionsToResult)
  .mapOk(data => data.consent.consentUrl)
  .tapOk(url => window.location.replace(url))
  .tapError(error => showToast({ variant: "error", title: translateError(error) }));
```