### PR TITLE
3D card: Add custom texture

### DIFF
--- a/packages/lake/src/components/Card3dPreview.tsx
+++ b/packages/lake/src/components/Card3dPreview.tsx
@@ -79,7 +79,7 @@ type CardParams = {
   cardNumber: string;
   expirationDate: string;
   cvv: string;
-  color: "Silver" | "Black";
+  color: "Silver" | "Black" | THREE.Texture;
   logo: SVGElement | HTMLImageElement | null;
   logoScale: number;
   assetsUrls: Card3dAssetsUrls;
@@ -256,7 +256,9 @@ export const Card = forwardRef<THREE.Group, CardProps>(
         .with("Black", () => {
           materials.card.map = blackTexture;
         })
-        .exhaustive();
+        .otherwise(texture => {
+          materials.card.map = texture;
+        });
 
       // force threejs to update material
       // because sometimes it doesn't apply texture on load randomly
@@ -306,7 +308,7 @@ export const Card = forwardRef<THREE.Group, CardProps>(
         color={match(color)
           .with("Silver", () => 0x000000)
           .with("Black", () => 0xeeeeee)
-          .exhaustive()}
+          .otherwise(() => 0xeeeeee)}
         metalness={0.1}
         roughness={0.55}
         envMapIntensity={ENV_MAP_INTENSITY}
@@ -500,7 +502,7 @@ export const Card = forwardRef<THREE.Group, CardProps>(
                   color={match(color)
                     .with("Silver", () => 0x000000)
                     .with("Black", () => 0xffffff)
-                    .exhaustive()}
+                    .otherwise(() => 0xffffff)}
                   metalness={0.1}
                   roughness={0.35}
                   envMapIntensity={ENV_MAP_INTENSITY}

--- a/packages/lake/src/components/Card3dPreview.tsx
+++ b/packages/lake/src/components/Card3dPreview.tsx
@@ -414,7 +414,7 @@ export const Card = forwardRef<THREE.Group, CardProps>(
               rotation={[0, Math.PI, 0]}
               position={[4, -0.15, 0]}
             >
-              by Mastercard international.
+              from Mastercard International.
               {secondaryTextMaterial}
             </Text>
 


### PR DESCRIPTION
Hello Swan team!

I hope your week started well.

I create this PR for 2 reasons:

1️⃣ Fix a wording issue  
At back of the card, there were written `by Mastercard international.` whereas we should write `from Mastercard International.`

2️⃣ Add the possibility to add custom color  
The marketing team asked for the 3D card studio the possibility to set a custom color when user select `Custom` option.  
And I thought the best idea is giving the possibility to directly set a custom texture (which is just a jpg image applied on 3D model). So in case we want to change the custom color, we can do it without changing code in Lake.  
The only caveat is about text + logo color. We'll use purple for card studio, and I don't think we'll use light colors so at the moment I set text and logo color white.