### PR TITLE
feat(LakeTextInput): add unit chooser

### DIFF
--- a/packages/lake/__stories__/TextInput.stories.tsx
+++ b/packages/lake/__stories__/TextInput.stories.tsx
@@ -33,6 +33,25 @@ const EditableInputText = (props: Except<LakeTextInputProps, "value" | "onChange
   );
 };
 
+const EditableInputTextWithUnitChooser = (
+  props: Except<LakeTextInputProps, "value" | "onChange">,
+) => {
+  const [value, setValue] = useState(props.defaultValue ?? "");
+  const [unit, setUnit] = useState(props.unit);
+
+  return (
+    <View style={styles.input}>
+      <LakeTextInput
+        {...props}
+        unit={unit}
+        value={value}
+        onUnitChange={setUnit}
+        onChange={event => setValue(event.currentTarget.value)}
+      />
+    </View>
+  );
+};
+
 export const Variations = () => {
   return (
     <StoryBlock title="Input variations">
@@ -101,6 +120,14 @@ export const Variations = () => {
 
       <StoryPart title="With unit">
         <EditableInputText unit="$" />
+      </StoryPart>
+
+      <StoryPart title="With unit chooser">
+        <EditableInputTextWithUnitChooser
+          units={["EUR", "PLN", "USD"]}
+          unit="USD"
+          inputMode="numeric"
+        />
       </StoryPart>
 
       <StoryPart title="With end icon and custom injected component">

--- a/packages/lake/src/components/LakeTextInput.tsx
+++ b/packages/lake/src/components/LakeTextInput.tsx
@@ -35,6 +35,7 @@ import { isNotNullish, isNotNullishOrEmpty, isNullish } from "../utils/nullish";
 import { Box } from "./Box";
 import { Fill } from "./Fill";
 import { Icon, IconName } from "./Icon";
+import { LakeSelect } from "./LakeSelect";
 import { LakeText } from "./LakeText";
 
 const TRANSPARENT = "transparent";
@@ -133,6 +134,8 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderLeftWidth: 0,
     flexShrink: 0,
+    borderTopLeftRadius: 0,
+    borderBottomLeftRadius: 0,
   },
   unitDisabled: {
     borderColor: colors.gray[50],
@@ -165,6 +168,7 @@ export type LakeTextInputProps = Except<
   multiline?: boolean;
   icon?: IconName;
   unit?: string;
+  units?: string[];
   inputMode?: TextInputProps["inputMode"];
   pattern?: string;
   children?: ReactNode;
@@ -172,6 +176,7 @@ export type LakeTextInputProps = Except<
   style?: TextInputProps["style"];
   containerStyle?: ViewProps["style"];
   onChange?: ChangeEventHandler<HTMLInputElement>;
+  onUnitChange?: (value: string) => void;
   maxCharCount?: number;
   help?: string;
   renderEnd?: () => ReactNode;
@@ -191,10 +196,12 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
       icon,
       children,
       unit,
+      units,
       color = "gray",
       inputMode = "text",
       hideErrors = false,
       onChange,
+      onUnitChange,
       pattern,
       style: stylesFromProps,
       containerStyle: containerStylesFromProps,
@@ -259,7 +266,7 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
                 disabled && styles.disabled,
                 readOnly && styles.readOnly,
                 isFocused && styles.focused,
-                isNotNullish(unit) && styles.inputWithUnit,
+                isNotNullish(unit ?? units) && styles.inputWithUnit,
                 hasError && styles.error,
                 valid && styles.valid,
                 stylesFromProps,
@@ -321,14 +328,26 @@ export const LakeTextInput = forwardRef<TextInput | null, LakeTextInputProps>(
               )}
             </View>
 
-            {isNotNullish(unit) && (
+            {isNotNullish(units) && isNotNullish(onUnitChange) ? (
+              <Box>
+                <LakeSelect
+                  value={unit}
+                  onValueChange={onUnitChange}
+                  items={units.map(value => ({ name: value, value }))}
+                  disabled={disabled}
+                  style={[styles.unit, (disabled || readOnly) && styles.unitDisabled]}
+                  mode="borderless"
+                  hideErrors={true}
+                />
+              </Box>
+            ) : isNotNullish(unit) ? (
               <LakeText
                 color={colors.gray[900]}
                 style={[styles.unit, (disabled || readOnly) && styles.unitDisabled]}
               >
                 {unit}
               </LakeText>
-            )}
+            ) : null}
           </View>
 
           {children}


### PR DESCRIPTION
<img width="484" alt="image" src="https://github.com/swan-io/lake/assets/26482371/f74d35dc-c70f-4164-8c02-f915bfc4f500">
<img width="496" alt="image" src="https://github.com/swan-io/lake/assets/26482371/2e38f901-976f-4452-bee1-04b43352aa1f">
