### PR TITLE
add font variant numeric type

### DIFF
--- a/types/react-native/index.d.ts
+++ b/types/react-native/index.d.ts
@@ -390,6 +390,21 @@ declare module "react-native" {
   export interface TextStyle extends AnimationStyles, InteractionStyles, TransformsStyle {
     display?: DisplayValue;
     fontFeatureSettings?: string;
+    fontVariantNumeric?:
+      | "normal"
+      | "ordinal"
+      | "slashed-zero"
+      | "lining-nums"
+      | "oldstyle-nums"
+      | "proportional-nums"
+      | "tabular-nums"
+      | "diagonal-fractions"
+      | "stacked-fractions"
+      | "inherit"
+      | "initial"
+      | "revert"
+      | "revert-layer"
+      | "unset";
     textOverflow?: "clip" | "ellipsis";
     textTransform?: "none" | "capitalize" | "uppercase" | "lowercase";
     transform?: string;


### PR DESCRIPTION
Hello there !

I created this PR just to add `fontVariantNumeric` type in `TextStyle`. This can be useful if you want to update numeric values without layout shift, here is a video showing the difference without and without: https://twitter.com/wesbos/status/932644812582522880/

Values comes from https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric

Wish you a nice day !