### PR TITLE
Shift group names a bit lower

### DIFF
--- a/packages/lake/src/components/PlainListView.tsx
+++ b/packages/lake/src/components/PlainListView.tsx
@@ -390,6 +390,7 @@ export const PlainListView = <T, ExtraInfo>({
                                 large && styles.stickyHeaderLarge,
                                 {
                                   height: groupHeaderHeight,
+                                  paddingTop: groupHeaderHeight / 4,
                                   top: stickyOffset + (large ? headerHeight : 0),
                                 },
                               ]}


### PR DESCRIPTION
A subtle change to shift the group names by 1/4 to the bottom.

From this:

![Screenshot 2024-07-25 at 10 57 27](https://github.com/user-attachments/assets/fdb5afbb-310a-4efa-bdbe-2a47b7a270aa)

To this:

![Screenshot 2024-07-25 at 10 57 20](https://github.com/user-attachments/assets/c2afa28d-48e1-40a0-8ceb-b96c99c01ec5)