### PR TITLE
fix: removed the role="button" from the outer Pressable

### DIFF
--- a/packages/lake/src/components/MultiSelect.tsx
+++ b/packages/lake/src/components/MultiSelect.tsx
@@ -312,7 +312,6 @@ export const MultiSelect = <Value,>({
         id={id}
         ref={inputRef}
         aria-haspopup="listbox"
-        role="button"
         aria-expanded={visible}
         disabled={disabled}
         onPress={open}


### PR DESCRIPTION
Removed the role="button" from the outer Pressable since it's acting more as a container/input

This caused the following warning:
```
Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>. Error Component Stack
```