### PR TITLE
Improve inline datepicker validation

### DIFF
--- a/packages/shared-business/src/components/InlineDatePicker.tsx
+++ b/packages/shared-business/src/components/InlineDatePicker.tsx
@@ -87,6 +87,7 @@ export const InlineDatePicker = ({
   // validate will not be triggered again since the field has already
   // blurred = true
   const touched = useRef(new Set<"day" | "month" | "year">());
+  const mountWithInitialValue = useRef(value != null);
 
   const { Field, validateField } = useForm({
     date: {
@@ -114,7 +115,10 @@ export const InlineDatePicker = ({
   });
 
   const validateDate = () => {
-    if (touched.current.has("day") && touched.current.has("month") && touched.current.has("year")) {
+    if (
+      mountWithInitialValue.current ||
+      (touched.current.has("day") && touched.current.has("month") && touched.current.has("year"))
+    ) {
       validateField("date");
     }
   };

--- a/packages/shared-business/src/components/InlineDatePicker.tsx
+++ b/packages/shared-business/src/components/InlineDatePicker.tsx
@@ -14,6 +14,7 @@ import { match } from "ts-pattern";
 import { extractDate, ExtractedDate, formatExtractedDate } from "../utils/date";
 import { t } from "../utils/i18n";
 import { getMostLikelyUserCountry } from "../utils/localization";
+import { validateDate } from "../utils/validation";
 
 const months = [
   { value: "01", name: t("datePicker.month.january") },
@@ -75,7 +76,7 @@ export const InlineDatePicker = ({
   label,
   readOnly = false,
   onValueChange,
-  validate = () => undefined,
+  validate = validateDate,
   error: externalError,
   style,
 }: InlineDatePickerProps) => {

--- a/packages/shared-business/src/locales/de.json
+++ b/packages/shared-business/src/locales/de.json
@@ -407,5 +407,6 @@
   "transactionStatement.type.SepaInstantCreditTransferIn": "SEPA Sofortüberweisung erhalten",
   "transactionStatement.type.SepaInstantCreditTransferOut": "SEPA Sofortüberweisung gesendet",
   "validation.birthdateCannotBeFuture": "Geburtsdatum darf nicht in der Zukunft liegen",
-  "validation.invalidBirthDate": "Bitte geben Sie ein gültiges Geburtsdatum ein."
+  "validation.invalidBirthDate": "Bitte geben Sie ein gültiges Geburtsdatum ein.",
+  "validation.invalidDate": "Bitte geben Sie ein gültiges Datum ein."
 }

--- a/packages/shared-business/src/locales/en.json
+++ b/packages/shared-business/src/locales/en.json
@@ -407,5 +407,6 @@
   "transactionStatement.type.SepaInstantCreditTransferIn": "SEPA Instant Credit Transfer received",
   "transactionStatement.type.SepaInstantCreditTransferOut": "SEPA Instant Credit Transfer sent",
   "validation.birthdateCannotBeFuture": "Birthdate cannot be in the future",
-  "validation.invalidBirthDate": "Please enter a valid birth date."
+  "validation.invalidBirthDate": "Please enter a valid birth date.",
+  "validation.invalidDate": "Please enter a valid date."
 }

--- a/packages/shared-business/src/locales/es.json
+++ b/packages/shared-business/src/locales/es.json
@@ -407,5 +407,6 @@
   "transactionStatement.type.SepaInstantCreditTransferIn": "Transferencia SEPA instantánea recibida",
   "transactionStatement.type.SepaInstantCreditTransferOut": "Transferencia SEPA instantánea enviada",
   "validation.birthdateCannotBeFuture": "La fecha de nacimiento no puede estar en el futuro",
-  "validation.invalidBirthDate": "Por favor, introduce una fecha de nacimiento válida."
+  "validation.invalidBirthDate": "Por favor, introduce una fecha de nacimiento válida.",
+  "validation.invalidDate": "Por favor, introduce una fecha válida."
 }

--- a/packages/shared-business/src/locales/fi.json
+++ b/packages/shared-business/src/locales/fi.json
@@ -407,5 +407,6 @@
   "transactionStatement.type.SepaInstantCreditTransferIn": "SEPA Instant -tilisiirto vastaanotettu",
   "transactionStatement.type.SepaInstantCreditTransferOut": "SEPA Instant -tilisiirto lähetetty",
   "validation.birthdateCannotBeFuture": "Syntymäaika ei voi olla tulevaisuudessa",
-  "validation.invalidBirthDate": "Syötä syntymäaika oikeassa muodossa."
+  "validation.invalidBirthDate": "Syötä syntymäaika oikeassa muodossa.",
+  "validation.invalidDate": "Syötä kelvollinen päivämäärä."
 }

--- a/packages/shared-business/src/locales/fr.json
+++ b/packages/shared-business/src/locales/fr.json
@@ -407,5 +407,6 @@
   "transactionStatement.type.SepaInstantCreditTransferIn": "Virement SEPA instantané reçu",
   "transactionStatement.type.SepaInstantCreditTransferOut": "Virement SEPA instantané envoyé",
   "validation.birthdateCannotBeFuture": "La date de naissance ne peut pas être dans le futur",
-  "validation.invalidBirthDate": "Veuillez saisir une date de naissance valide."
+  "validation.invalidBirthDate": "Veuillez saisir une date de naissance valide.",
+  "validation.invalidDate": "Veuillez saisir une date valide."
 }

--- a/packages/shared-business/src/locales/it.json
+++ b/packages/shared-business/src/locales/it.json
@@ -407,5 +407,6 @@
   "transactionStatement.type.SepaInstantCreditTransferIn": "Bonifico istantaneo SEPA ricevuto",
   "transactionStatement.type.SepaInstantCreditTransferOut": "Bonifico istantaneo SEPA inviato",
   "validation.birthdateCannotBeFuture": "La data di nascita non può essere nel futuro",
-  "validation.invalidBirthDate": "Inserisci una data di nascita valida."
+  "validation.invalidBirthDate": "Inserisci una data di nascita valida.",
+  "validation.invalidDate": "Inserisci una data valida."
 }

--- a/packages/shared-business/src/locales/nl.json
+++ b/packages/shared-business/src/locales/nl.json
@@ -407,5 +407,6 @@
   "transactionStatement.type.SepaInstantCreditTransferIn": "SEPA Instant-overschrijving ontvangen",
   "transactionStatement.type.SepaInstantCreditTransferOut": "SEPA Instant-overschrijving verzonden",
   "validation.birthdateCannotBeFuture": "Geboortedatum kan niet in de toekomst liggen",
-  "validation.invalidBirthDate": "Voer een geldige geboortedatum in."
+  "validation.invalidBirthDate": "Voer een geldige geboortedatum in.",
+  "validation.invalidDate": "Voer alstublieft een geldige datum in."
 }

--- a/packages/shared-business/src/locales/pt.json
+++ b/packages/shared-business/src/locales/pt.json
@@ -407,5 +407,6 @@
   "transactionStatement.type.SepaInstantCreditTransferIn": "Transferência de crédito instantânea SEPA recebida",
   "transactionStatement.type.SepaInstantCreditTransferOut": "Transferência de crédito instantânea SEPA enviada",
   "validation.birthdateCannotBeFuture": "A data de nascimento não pode estar no futuro",
-  "validation.invalidBirthDate": "Por favor, introduza uma data de nascimento válida."
+  "validation.invalidBirthDate": "Por favor, introduza uma data de nascimento válida.",
+  "validation.invalidDate": "Por favor, insira uma data válida."
 }

--- a/packages/shared-business/src/utils/validation.ts
+++ b/packages/shared-business/src/utils/validation.ts
@@ -132,6 +132,16 @@ export const validateIban = (iban: string) => {
   }
 };
 
+export const validateDate = (value: ExtractedDate | undefined) => {
+  if (isNullish(value)) {
+    return t("validation.invalidDate");
+  }
+  const date = dayjs.utc(formatExtractedDate(value), "YYYY-MM-DD", true);
+  if (!date.isValid()) {
+    return t("validation.invalidDate");
+  }
+};
+
 export const validateBirthdate = (value: ExtractedDate | undefined) => {
   if (isNullish(value)) {
     return t("validation.invalidBirthDate");


### PR DESCRIPTION
This PR changes 2 behaviors in `InlineDatePicker` :
- trigger validation if there was an initial value even if all fields wasn't touched yet
- set a default date validator