### PR TITLE
[ENP-4498] Remove duplicate .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-* @swan-io/front
-


### PR DESCRIPTION
## Summary
- Remove `.github/CODEOWNERS` to consolidate ownership definitions at the root `CODEOWNERS` (which GitHub will now use)

## Linear
https://linear.app/swan/issue/ENP-4498/github-remove-duplicate-githubcodeowners-files-11-repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)